### PR TITLE
Clip balances at zero.

### DIFF
--- a/substreams/crates/tycho-substreams/src/models.rs
+++ b/substreams/crates/tycho-substreams/src/models.rs
@@ -43,38 +43,50 @@ impl From<&sf::Block> for Block {
 }
 
 impl ProtocolComponent {
-    /// Creates a new empty `ProtocolComponent` instance.
+    /// Constructs a new, empty `ProtocolComponent`.
     ///
-    /// You can use the `with_*` methods to set the fields in a convience way.
+    /// Initializes an instance with default values. Use `with_*` methods to populate fields
+    /// conveniently.
+    ///
+    /// ## Parameters
+    /// - `id`: Identifier for the component.
+    /// - `tx`: Reference to the associated transaction.
     pub fn new(id: &str, tx: &Transaction) -> Self {
         Self {
             id: id.to_string(),
-            tokens: vec![],
-            contracts: vec![],
-            static_att: vec![],
+            tokens: Vec::new(),
+            contracts: Vec::new(),
+            static_att: Vec::new(),
             change: ChangeType::Creation.into(),
             protocol_type: None,
             tx: Some(tx.clone()),
         }
     }
 
-    /// Shorthand to create a component with a 1-1 relationship to a contract.
+    /// Initializes a `ProtocolComponent` with a direct association to a contract.
     ///
-    /// Will set the component id to a hex encoded address with a 0x prefix
-    /// and add the contract to contracts attributes.
+    /// Sets the component's ID to the hex-encoded address with a `0x` prefix and includes the
+    /// contract in the contracts list.
+    ///
+    /// ## Parameters
+    /// - `id`: Contract address to be encoded and set as the component's ID.
+    /// - `tx`: Reference to the associated transaction.
     pub fn at_contract(id: &[u8], tx: &Transaction) -> Self {
         Self {
             id: format!("0x{}", hex::encode(id)),
-            tokens: vec![],
+            tokens: Vec::new(),
             contracts: vec![id.to_vec()],
-            static_att: vec![],
+            static_att: Vec::new(),
             change: ChangeType::Creation.into(),
             protocol_type: None,
             tx: Some(tx.clone()),
         }
     }
 
-    /// Replaces the tokens on this component.
+    /// Updates the tokens associated with this component.
+    ///
+    /// ## Parameters
+    /// - `tokens`: Slice of byte slices representing the tokens to associate.
     pub fn with_tokens<B: AsRef<[u8]>>(mut self, tokens: &[B]) -> Self {
         self.tokens = tokens
             .iter()
@@ -83,7 +95,10 @@ impl ProtocolComponent {
         self
     }
 
-    /// Replaces the contracts associated with this component.
+    /// Updates the contracts associated with this component.
+    ///
+    /// ## Parameters
+    /// - `contracts`: Slice of byte slices representing the contracts to associate.
     pub fn with_contracts<B: AsRef<[u8]>>(mut self, contracts: &[B]) -> Self {
         self.contracts = contracts
             .iter()
@@ -92,9 +107,12 @@ impl ProtocolComponent {
         self
     }
 
-    /// Replaces the static attributes on this component.
+    /// Updates the static attributes of this component.
     ///
-    /// The change type will be set to Creation.
+    /// Sets the change type to `Creation` for all attributes.
+    ///
+    /// ## Parameters
+    /// - `attributes`: Slice of key-value pairs representing the attributes to set.
     pub fn with_attributes<K: AsRef<str>, V: AsRef<[u8]>>(mut self, attributes: &[(K, V)]) -> Self {
         self.static_att = attributes
             .iter()
@@ -107,15 +125,19 @@ impl ProtocolComponent {
         self
     }
 
-    /// Sets the protocol_type on this component.
+    /// Designates this component as a swap type within the protocol.
     ///
-    /// Will set the `financial_type` to FinancialType::Swap and the
-    /// `attribute_schema` to an empty list.
+    /// Sets the `protocol_type` accordingly, including `financial_type` as `Swap` and leaving
+    /// `attribute_schema` empty.
+    ///
+    /// ## Parameters
+    /// - `name`: The name of the swap protocol.
+    /// - `implementation_type`: The implementation type of the protocol.
     pub fn as_swap_type(mut self, name: &str, implementation_type: ImplementationType) -> Self {
         self.protocol_type = Some(ProtocolType {
             name: name.to_string(),
             financial_type: FinancialType::Swap.into(),
-            attribute_schema: vec![],
+            attribute_schema: Vec::new(),
             implementation_type: implementation_type.into(),
         });
         self


### PR DESCRIPTION
In case we get negative balances, which happens sometimes e.g. in balancer and seems to be due to some rounding issues within the protocol, we simply clip the balance at 0 so we never emit negative balances as tycho-indexer the upstream system will interpret the balance bytes as unsigned integers.