### PR TITLE
Remove IERC20 from ISwapAdapter and use SafeERC20 for IERC20

### DIFF
--- a/evm/src/interfaces/ISwapAdapter.sol
+++ b/evm/src/interfaces/ISwapAdapter.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
-import {IERC20} from "openzeppelin-contracts/contracts/interfaces/IERC20.sol";
 import {ISwapAdapterTypes} from "src/interfaces/ISwapAdapterTypes.sol";
 
 /// @title ISwapAdapter
@@ -35,8 +34,8 @@ interface ISwapAdapter is ISwapAdapterTypes {
     /// provided amounts.
     function price(
         bytes32 poolId,
-        IERC20 sellToken,
-        IERC20 buyToken,
+        address sellToken,
+        address buyToken,
         uint256[] memory specifiedAmounts
     ) external view returns (Fraction[] memory prices);
 
@@ -59,8 +58,8 @@ interface ISwapAdapter is ISwapAdapterTypes {
      */
     function swap(
         bytes32 poolId,
-        IERC20 sellToken,
-        IERC20 buyToken,
+        address sellToken,
+        address buyToken,
         OrderSide side,
         uint256 specifiedAmount
     ) external returns (Trade memory trade);
@@ -76,25 +75,27 @@ interface ISwapAdapter is ISwapAdapterTypes {
     /// @param sellToken The token being sold.
     /// @param buyToken The token being bought.
     /// @return limits An array of limits.
-    function getLimits(bytes32 poolId, IERC20 sellToken, IERC20 buyToken)
+    function getLimits(bytes32 poolId, address sellToken, address buyToken)
         external
         returns (uint256[] memory limits);
 
     /// @notice Retrieves the capabilities of the selected pool.
     /// @param poolId The ID of the trading pool.
     /// @return capabilities An array of Capability.
-    function getCapabilities(bytes32 poolId, IERC20 sellToken, IERC20 buyToken)
-        external
-        returns (Capability[] memory capabilities);
+    function getCapabilities(
+        bytes32 poolId,
+        address sellToken,
+        address buyToken
+    ) external returns (Capability[] memory capabilities);
 
     /// @notice Retrieves the tokens in the selected pool.
     /// @dev Mainly used for testing as this is redundant with the required
     /// substreams implementation.
     /// @param poolId The ID of the trading pool.
-    /// @return tokens An array of IERC20 contracts.
+    /// @return tokens An array of address contracts.
     function getTokens(bytes32 poolId)
         external
-        returns (IERC20[] memory tokens);
+        returns (address[] memory tokens);
 
     /// @notice Retrieves a range of pool IDs.
     /// @dev Mainly used for testing. It is alright to not return all available

--- a/evm/src/interfaces/ISwapAdapterTypes.sol
+++ b/evm/src/interfaces/ISwapAdapterTypes.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
-import {IERC20} from "openzeppelin-contracts/contracts/interfaces/IERC20.sol";
-
 interface ISwapAdapterTypes {
     /// @dev The OrderSide enum represents possible sides of a trade: Sell or
     /// Buy. E.g. if OrderSide is Sell, the sell amount is interpreted to be

--- a/evm/src/template/TemplateSwapAdapter.sol
+++ b/evm/src/template/TemplateSwapAdapter.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
-import {IERC20, ISwapAdapter} from "src/interfaces/ISwapAdapter.sol";
+import {ISwapAdapter} from "src/interfaces/ISwapAdapter.sol";
 
 /// @title TemplateSwapAdapter
 /// @dev This is a template for a swap adapter.
@@ -10,8 +10,8 @@ import {IERC20, ISwapAdapter} from "src/interfaces/ISwapAdapter.sol";
 contract TemplateSwapAdapter is ISwapAdapter {
     function price(
         bytes32 _poolId,
-        IERC20 _sellToken,
-        IERC20 _buyToken,
+        address _sellToken,
+        address _buyToken,
         uint256[] memory _specifiedAmounts
     ) external view override returns (Fraction[] memory _prices) {
         revert NotImplemented("TemplateSwapAdapter.price");
@@ -19,31 +19,32 @@ contract TemplateSwapAdapter is ISwapAdapter {
 
     function swap(
         bytes32 poolId,
-        IERC20 sellToken,
-        IERC20 buyToken,
+        address sellToken,
+        address buyToken,
         OrderSide side,
         uint256 specifiedAmount
     ) external returns (Trade memory trade) {
         revert NotImplemented("TemplateSwapAdapter.swap");
     }
 
-    function getLimits(bytes32 poolId, IERC20 sellToken, IERC20 buyToken)
+    function getLimits(bytes32 poolId, address sellToken, address buyToken)
         external
         returns (uint256[] memory limits)
     {
         revert NotImplemented("TemplateSwapAdapter.getLimits");
     }
 
-    function getCapabilities(bytes32 poolId, IERC20 sellToken, IERC20 buyToken)
-        external
-        returns (Capability[] memory capabilities)
-    {
+    function getCapabilities(
+        bytes32 poolId,
+        address sellToken,
+        address buyToken
+    ) external returns (Capability[] memory capabilities) {
         revert NotImplemented("TemplateSwapAdapter.getCapabilities");
     }
 
     function getTokens(bytes32 poolId)
         external
-        returns (IERC20[] memory tokens)
+        returns (address[] memory tokens)
     {
         revert NotImplemented("TemplateSwapAdapter.getTokens");
     }

--- a/evm/test/UniswapV2SwapAdapter.t.sol
+++ b/evm/test/UniswapV2SwapAdapter.t.sol
@@ -11,8 +11,8 @@ contract UniswapV2PairFunctionTest is Test, ISwapAdapterTypes {
     using FractionMath for Fraction;
 
     UniswapV2SwapAdapter adapter;
-    IERC20 constant WETH = IERC20(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
-    IERC20 constant USDC = IERC20(0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48);
+    address constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
+    address constant USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
     address constant USDC_WETH_PAIR = 0xB4e16d0168e52d35CaCD2c6185b44281Ec28C9Dc;
 
     uint256 constant TEST_ITERATIONS = 100;
@@ -24,9 +24,9 @@ contract UniswapV2PairFunctionTest is Test, ISwapAdapterTypes {
             new UniswapV2SwapAdapter(0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f);
 
         vm.label(address(adapter), "UniswapV2SwapAdapter");
-        vm.label(address(WETH), "WETH");
-        vm.label(address(USDC), "USDC");
-        vm.label(address(USDC_WETH_PAIR), "USDC_WETH_PAIR");
+        vm.label(WETH, "WETH");
+        vm.label(USDC, "USDC");
+        vm.label(USDC_WETH_PAIR, "USDC_WETH_PAIR");
     }
 
     function testPriceFuzz(uint256 amount0, uint256 amount1) public {
@@ -75,17 +75,17 @@ contract UniswapV2PairFunctionTest is Test, ISwapAdapterTypes {
 
             // TODO calculate the amountIn by using price function as in
             // BalancerV2 testPriceDecreasing
-            deal(address(USDC), address(this), type(uint256).max);
-            USDC.approve(address(adapter), type(uint256).max);
+            deal(USDC, address(this), type(uint256).max);
+            IERC20(USDC).approve(address(adapter), type(uint256).max);
         } else {
             vm.assume(specifiedAmount < limits[0]);
 
-            deal(address(USDC), address(this), specifiedAmount);
-            USDC.approve(address(adapter), specifiedAmount);
+            deal(USDC, address(this), specifiedAmount);
+            IERC20(USDC).approve(address(adapter), specifiedAmount);
         }
 
-        uint256 usdc_balance = USDC.balanceOf(address(this));
-        uint256 weth_balance = WETH.balanceOf(address(this));
+        uint256 usdc_balance = IERC20(USDC).balanceOf(address(this));
+        uint256 weth_balance = IERC20(WETH).balanceOf(address(this));
 
         Trade memory trade =
             adapter.swap(pair, USDC, WETH, side, specifiedAmount);
@@ -94,20 +94,20 @@ contract UniswapV2PairFunctionTest is Test, ISwapAdapterTypes {
             if (side == OrderSide.Buy) {
                 assertEq(
                     specifiedAmount,
-                    WETH.balanceOf(address(this)) - weth_balance
+                    IERC20(WETH).balanceOf(address(this)) - weth_balance
                 );
                 assertEq(
                     trade.calculatedAmount,
-                    usdc_balance - USDC.balanceOf(address(this))
+                    usdc_balance - IERC20(USDC).balanceOf(address(this))
                 );
             } else {
                 assertEq(
                     specifiedAmount,
-                    usdc_balance - USDC.balanceOf(address(this))
+                    usdc_balance - IERC20(USDC).balanceOf(address(this))
                 );
                 assertEq(
                     trade.calculatedAmount,
-                    WETH.balanceOf(address(this)) - weth_balance
+                    IERC20(WETH).balanceOf(address(this)) - weth_balance
                 );
             }
         }
@@ -130,8 +130,8 @@ contract UniswapV2PairFunctionTest is Test, ISwapAdapterTypes {
         for (uint256 i = 0; i < TEST_ITERATIONS; i++) {
             beforeSwap = vm.snapshot();
 
-            deal(address(USDC), address(this), amounts[i]);
-            USDC.approve(address(adapter), amounts[i]);
+            deal(USDC, address(this), amounts[i]);
+            IERC20(USDC).approve(address(adapter), amounts[i]);
 
             trades[i] = adapter.swap(pair, USDC, WETH, side, amounts[i]);
             vm.revertTo(beforeSwap);
@@ -149,8 +149,7 @@ contract UniswapV2PairFunctionTest is Test, ISwapAdapterTypes {
     }
 
     function testGetCapabilities(bytes32 pair, address t0, address t1) public {
-        Capability[] memory res =
-            adapter.getCapabilities(pair, IERC20(t0), IERC20(t1));
+        Capability[] memory res = adapter.getCapabilities(pair, t0, t1);
 
         assertEq(res.length, 3);
     }


### PR DESCRIPTION
1. Use SafeERC20
2. Remove IERC20 from ISwapAdapter to remove unnecessary type casting