### PR TITLE
Revert "ENG-3406: Add new bytes parameter to swap"

### DIFF
--- a/evm/src/angle/AngleAdapter.sol
+++ b/evm/src/angle/AngleAdapter.sol
@@ -56,8 +56,7 @@ contract AngleAdapter is ISwapAdapter {
         address sellToken,
         address buyToken,
         OrderSide side,
-        uint256 specifiedAmount,
-        bytes32
+        uint256 specifiedAmount
     ) external returns (Trade memory trade) {
         if (specifiedAmount == 0) {
             return trade;
@@ -224,7 +223,7 @@ contract AngleAdapter is ISwapAdapter {
 
 interface IAgToken is IERC20 {
     /*//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    MINTER ROLE ONLY FUNCTIONS
+    MINTER ROLE ONLY FUNCTIONS                                            
     //////////////////////////////////////////////////////////////////////////////////////////////////////////////////*/
 
     /// @notice Lets a whitelisted contract mint agTokens
@@ -255,7 +254,7 @@ interface IAgToken is IERC20 {
     function burnSelf(uint256 amount, address burner) external;
 
     /*//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    TREASURY ONLY FUNCTIONS
+    TREASURY ONLY FUNCTIONS                                             
     //////////////////////////////////////////////////////////////////////////////////////////////////////////////////*/
 
     /// @notice Adds a minter in the contract
@@ -275,7 +274,7 @@ interface IAgToken is IERC20 {
     function setTreasury(address _treasury) external;
 
     /*//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    EXTERNAL FUNCTIONS
+    EXTERNAL FUNCTIONS                                                
     //////////////////////////////////////////////////////////////////////////////////////////////////////////////////*/
 
     /// @notice Checks whether an address has the right to mint agTokens

--- a/evm/src/balancer-v2/BalancerV2SwapAdapter.sol
+++ b/evm/src/balancer-v2/BalancerV2SwapAdapter.sol
@@ -118,12 +118,10 @@ contract BalancerV2SwapAdapter is ISwapAdapter {
         address sellToken,
         address buyToken,
         OrderSide side,
-        uint256 specifiedAmount,
-        bytes32 data
+        uint256 specifiedAmount
     ) external override returns (Trade memory trade) {
         uint256 sellAmount;
         IVault.SwapKind kind;
-        bool reduceFee = abi.decode(abi.encodePacked(data), (bool));
         uint256 limit; // TODO set this slippage limit properly
         if (side == OrderSide.Sell) {
             kind = IVault.SwapKind.GIVEN_IN;

--- a/evm/src/etherfi/EtherfiAdapter.sol
+++ b/evm/src/etherfi/EtherfiAdapter.sol
@@ -99,8 +99,7 @@ contract EtherfiAdapter is ISwapAdapter {
         address sellToken,
         address buyToken,
         OrderSide side,
-        uint256 specifiedAmount,
-        bytes32
+        uint256 specifiedAmount
     )
         external
         override

--- a/evm/src/integral/IntegralSwapAdapter.sol
+++ b/evm/src/integral/IntegralSwapAdapter.sol
@@ -59,8 +59,7 @@ contract IntegralSwapAdapter is ISwapAdapter {
         address sellToken,
         address buyToken,
         OrderSide side,
-        uint256 specifiedAmount,
-        bytes32
+        uint256 specifiedAmount
     ) external override returns (Trade memory trade) {
         if (specifiedAmount == 0) {
             return trade;

--- a/evm/src/interfaces/ISwapAdapter.sol
+++ b/evm/src/interfaces/ISwapAdapter.sol
@@ -54,7 +54,6 @@ interface ISwapAdapter is ISwapAdapterTypes {
      * @param buyToken The token being bought.
      * @param side The side of the trade (Sell or Buy).
      * @param specifiedAmount The amount to be traded.
-     * @param data Additional arbitrary data for the swap.
      * @return trade Trade struct representing the executed trade.
      */
     function swap(
@@ -62,8 +61,7 @@ interface ISwapAdapter is ISwapAdapterTypes {
         address sellToken,
         address buyToken,
         OrderSide side,
-        uint256 specifiedAmount,
-        bytes32 data
+        uint256 specifiedAmount
     ) external returns (Trade memory trade);
 
     /// @notice Retrieves the limits for each token.

--- a/evm/src/template/TemplateSwapAdapter.sol
+++ b/evm/src/template/TemplateSwapAdapter.sol
@@ -22,8 +22,7 @@ contract TemplateSwapAdapter is ISwapAdapter {
         address sellToken,
         address buyToken,
         OrderSide side,
-        uint256 specifiedAmount,
-        bytes32
+        uint256 specifiedAmount
     ) external returns (Trade memory trade) {
         revert NotImplemented("TemplateSwapAdapter.swap");
     }

--- a/evm/src/uniswap-v2/UniswapV2SwapAdapter.sol
+++ b/evm/src/uniswap-v2/UniswapV2SwapAdapter.sol
@@ -66,8 +66,7 @@ contract UniswapV2SwapAdapter is ISwapAdapter {
         address sellToken,
         address buyToken,
         OrderSide side,
-        uint256 specifiedAmount,
-        bytes32
+        uint256 specifiedAmount
     ) external override returns (Trade memory trade) {
         if (specifiedAmount == 0) {
             return trade;

--- a/evm/test/AdapterTest.sol
+++ b/evm/test/AdapterTest.sol
@@ -10,7 +10,6 @@ import "src/libraries/FractionMath.sol";
 contract AdapterTest is Test, ISwapAdapterTypes {
     using FractionMath for Fraction;
 
-    bytes32 mockData;
     uint256 constant pricePrecision = 10e24;
     string[] public stringPctgs = ["0%", "0.1%", "50%", "100%"];
 
@@ -103,7 +102,7 @@ contract AdapterTest is Test, ISwapAdapterTypes {
 
             console2.log("TEST: Swapping %d of %s", amounts[j], tokenIn);
             trade = adapter.swap(
-                poolId, tokenIn, tokenOut, OrderSide.Sell, amounts[j], mockData
+                poolId, tokenIn, tokenOut, OrderSide.Sell, amounts[j]
             );
             uint256 executedPrice =
                 trade.calculatedAmount * pricePrecision / amounts[j];
@@ -192,12 +191,7 @@ contract AdapterTest is Test, ISwapAdapterTypes {
             );
         }
         try adapter.swap(
-            poolId,
-            tokenIn,
-            tokenOut,
-            OrderSide.Sell,
-            aboveLimitArray[0],
-            mockData
+            poolId, tokenIn, tokenOut, OrderSide.Sell, aboveLimitArray[0]
         ) {
             revert("Pool shouldn't be able to swap above the sell limit");
         } catch Error(string memory s) {
@@ -223,12 +217,7 @@ contract AdapterTest is Test, ISwapAdapterTypes {
 
         adapter.price(poolId, tokenIn, tokenOut, aboveLimitArray);
         adapter.swap(
-            poolId,
-            tokenIn,
-            tokenOut,
-            OrderSide.Sell,
-            aboveLimitArray[0],
-            mockData
+            poolId, tokenIn, tokenOut, OrderSide.Sell, aboveLimitArray[0]
         );
     }
 

--- a/evm/test/AngleAdapter.t.sol
+++ b/evm/test/AngleAdapter.t.sol
@@ -18,7 +18,6 @@ contract AngleAdapterTest is Test, ISwapAdapterTypes {
         ITransmuter(0x00253582b2a3FE112feEC532221d9708c64cEFAb);
 
     uint256 constant TEST_ITERATIONS = 100;
-    bytes32 mockData;
 
     function setUp() public {
         uint256 forkBlock = 18921770;
@@ -56,7 +55,7 @@ contract AngleAdapterTest is Test, ISwapAdapterTypes {
         uint256 agEUR_balance = agEUR.balanceOf(address(this));
 
         Trade memory trade = adapter.swap(
-            pair, address(EURC), address(agEUR), side, specifiedAmount, mockData
+            pair, address(EURC), address(agEUR), side, specifiedAmount
         );
 
         if (trade.calculatedAmount > 0) {
@@ -107,7 +106,7 @@ contract AngleAdapterTest is Test, ISwapAdapterTypes {
         uint256 agEUR_balance = agEUR.balanceOf(address(this));
 
         Trade memory trade = adapter.swap(
-            pair, address(agEUR), address(EURC), side, specifiedAmount, mockData
+            pair, address(agEUR), address(EURC), side, specifiedAmount
         );
 
         if (trade.calculatedAmount > 0) {
@@ -160,7 +159,7 @@ contract AngleAdapterTest is Test, ISwapAdapterTypes {
                 agEUR.approve(address(adapter), type(uint256).max);
             }
             trades[i] = adapter.swap(
-                pair, address(agEUR), address(EURC), side, amounts[i], mockData
+                pair, address(agEUR), address(EURC), side, amounts[i]
             );
             vm.revertTo(beforeSwap);
         }
@@ -179,20 +178,19 @@ contract AngleAdapterTest is Test, ISwapAdapterTypes {
 
     function testGetCapabilitiesAngle(bytes32 pair, address t0, address t1)
         public
-        view
     {
         Capability[] memory res = adapter.getCapabilities(pair, t0, t1);
 
         assertEq(res.length, 2);
     }
 
-    function testGetTokensAngle() public view {
+    function testGetTokensAngle() public {
         address[] memory tokens = adapter.getTokens(bytes32(0));
 
         assertGe(tokens.length, 2);
     }
 
-    function testGetLimitsAngle() public view {
+    function testGetLimitsAngle() public {
         bytes32 pair = bytes32(0);
         uint256[] memory limits =
             adapter.getLimits(pair, address(agEUR), address(EURC));

--- a/evm/test/BalancerV2SwapAdapter.t.sol
+++ b/evm/test/BalancerV2SwapAdapter.t.sol
@@ -12,7 +12,6 @@ import {FractionMath} from "src/libraries/FractionMath.sol";
 contract BalancerV2SwapAdapterTest is AdapterTest {
     using FractionMath for Fraction;
 
-    bytes32 mockBoolData = bytes32(abi.encode(false));
     IVault constant balancerV2Vault =
         IVault(payable(0xBA12222222228d8Ba445958a75a0704d566BF2C8));
     BalancerV2SwapAdapter adapter;
@@ -112,12 +111,7 @@ contract BalancerV2SwapAdapterTest is AdapterTest {
         uint256 weth_balance = IERC20(WETH).balanceOf(address(this));
 
         Trade memory trade = adapter.swap(
-            B_80BAL_20WETH_POOL_ID,
-            BAL,
-            WETH,
-            side,
-            specifiedAmount,
-            mockBoolData
+            B_80BAL_20WETH_POOL_ID, BAL, WETH, side, specifiedAmount
         );
 
         if (trade.calculatedAmount > 0) {
@@ -155,12 +149,7 @@ contract BalancerV2SwapAdapterTest is AdapterTest {
             deal(BAL, address(this), amounts[i]);
             IERC20(BAL).approve(address(adapter), amounts[i]);
             trades[i] = adapter.swap(
-                B_80BAL_20WETH_POOL_ID,
-                BAL,
-                WETH,
-                OrderSide.Sell,
-                amounts[i],
-                mockBoolData
+                B_80BAL_20WETH_POOL_ID, BAL, WETH, OrderSide.Sell, amounts[i]
             );
 
             vm.revertTo(beforeSwap);
@@ -191,12 +180,7 @@ contract BalancerV2SwapAdapterTest is AdapterTest {
             deal(BAL, address(this), amountIn);
             IERC20(BAL).approve(address(adapter), amountIn);
             trades[i] = adapter.swap(
-                B_80BAL_20WETH_POOL_ID,
-                BAL,
-                WETH,
-                OrderSide.Buy,
-                amounts[i],
-                mockBoolData
+                B_80BAL_20WETH_POOL_ID, BAL, WETH, OrderSide.Buy, amounts[i]
             );
 
             vm.revertTo(beforeSwap);
@@ -220,7 +204,6 @@ contract BalancerV2SwapAdapterTest is AdapterTest {
 
     function testGetCapabilitiesFuzz(bytes32 pool, address t0, address t1)
         public
-        view
     {
         Capability[] memory res = adapter.getCapabilities(pool, t0, t1);
 
@@ -228,10 +211,9 @@ contract BalancerV2SwapAdapterTest is AdapterTest {
         assertEq(uint256(res[0]), uint256(Capability.SellOrder));
         assertEq(uint256(res[1]), uint256(Capability.BuyOrder));
         assertEq(uint256(res[2]), uint256(Capability.PriceFunction));
-        assertEq(uint256(res[3]), uint256(Capability.HardLimits));
     }
 
-    function testGetTokens() public view {
+    function testGetTokens() public {
         address[] memory tokens = adapter.getTokens(B_80BAL_20WETH_POOL_ID);
 
         assertEq(tokens[0], BAL);

--- a/evm/test/EtherfiAdapter.t.sol
+++ b/evm/test/EtherfiAdapter.t.sol
@@ -15,7 +15,6 @@ contract EtherfiAdapterTest is Test, ISwapAdapterTypes {
     IeEth eEth;
 
     uint256 constant TEST_ITERATIONS = 100;
-    bytes32 mockData;
 
     function setUp() public {
         uint256 forkBlock = 19218495;
@@ -73,8 +72,7 @@ contract EtherfiAdapterTest is Test, ISwapAdapterTypes {
                 address(address(0)),
                 address(eEth_),
                 OrderSide.Buy,
-                limits[0],
-                mockData
+                limits[0]
             );
 
             eEth_.approve(address(adapter), type(uint256).max);
@@ -89,8 +87,7 @@ contract EtherfiAdapterTest is Test, ISwapAdapterTypes {
                 address(address(0)),
                 address(eEth_),
                 OrderSide.Buy,
-                specifiedAmount,
-                mockData
+                specifiedAmount
             );
 
             eEth_.approve(address(adapter), specifiedAmount);
@@ -100,12 +97,7 @@ contract EtherfiAdapterTest is Test, ISwapAdapterTypes {
         uint256 weEth_balance = weEth_.balanceOf(address(this));
 
         Trade memory trade = adapter.swap(
-            pair,
-            address(eEth_),
-            address(weEth_),
-            side,
-            specifiedAmount,
-            mockData
+            pair, address(eEth_), address(weEth_), side, specifiedAmount
         );
 
         if (trade.calculatedAmount > 0) {
@@ -172,8 +164,7 @@ contract EtherfiAdapterTest is Test, ISwapAdapterTypes {
                 address(address(0)),
                 address(weEth_),
                 OrderSide.Buy,
-                limits[0],
-                mockData
+                limits[0]
             );
 
             weEth_.approve(address(adapter), type(uint256).max);
@@ -188,8 +179,7 @@ contract EtherfiAdapterTest is Test, ISwapAdapterTypes {
                 address(address(0)),
                 address(weEth_),
                 OrderSide.Buy,
-                specifiedAmount,
-                mockData
+                specifiedAmount
             );
 
             weEth_.approve(address(adapter), specifiedAmount);
@@ -204,12 +194,7 @@ contract EtherfiAdapterTest is Test, ISwapAdapterTypes {
         uint256 realAmountWeEth_ = weEth_balance - weEth_bal_before;
 
         Trade memory trade = adapter.swap(
-            pair,
-            address(weEth_),
-            address(eEth_),
-            side,
-            realAmountWeEth_,
-            mockData
+            pair, address(weEth_), address(eEth_), side, realAmountWeEth_
         );
 
         if (trade.calculatedAmount > 0) {
@@ -269,9 +254,8 @@ contract EtherfiAdapterTest is Test, ISwapAdapterTypes {
         uint256 eth_balance = address(adapter).balance;
         uint256 eEth_balance = eEth_.balanceOf(address(this));
 
-        Trade memory trade = adapter.swap(
-            pair, eth_, address(eEth_), side, specifiedAmount, mockData
-        );
+        Trade memory trade =
+            adapter.swap(pair, eth_, address(eEth_), side, specifiedAmount);
 
         if (trade.calculatedAmount > 0) {
             if (side == OrderSide.Buy) {
@@ -325,9 +309,8 @@ contract EtherfiAdapterTest is Test, ISwapAdapterTypes {
         uint256 eth_balance = address(adapter).balance;
         uint256 weEth_balance = weEth_.balanceOf(address(this));
 
-        Trade memory trade = adapter.swap(
-            pair, eth_, address(weEth_), side, specifiedAmount, mockData
-        );
+        Trade memory trade =
+            adapter.swap(pair, eth_, address(weEth_), side, specifiedAmount);
 
         if (trade.calculatedAmount > 0) {
             if (side == OrderSide.Buy) {
@@ -390,8 +373,7 @@ contract EtherfiAdapterTest is Test, ISwapAdapterTypes {
                 address(address(weEth)),
                 address(address(eEth)),
                 side,
-                amounts[i],
-                mockData
+                amounts[i]
             );
             vm.revertTo(beforeSwap);
         }
@@ -404,7 +386,6 @@ contract EtherfiAdapterTest is Test, ISwapAdapterTypes {
 
     function testGetCapabilitiesEtherfi(bytes32 pair, address t0, address t1)
         public
-        view
     {
         Capability[] memory res =
             adapter.getCapabilities(pair, address(t0), address(t1));
@@ -412,14 +393,14 @@ contract EtherfiAdapterTest is Test, ISwapAdapterTypes {
         assertEq(res.length, 3);
     }
 
-    function testGetTokensEtherfi() public view {
+    function testGetTokensEtherfi() public {
         bytes32 pair = bytes32(0);
         address[] memory tokens = adapter.getTokens(pair);
 
         assertEq(tokens.length, 3);
     }
 
-    function testGetLimitsEtherfi() public view {
+    function testGetLimitsEtherfi() public {
         bytes32 pair = bytes32(0);
         uint256[] memory limits =
             adapter.getLimits(pair, address(eEth), address(weEth));

--- a/evm/test/IntegralSwapAdapter.t.sol
+++ b/evm/test/IntegralSwapAdapter.t.sol
@@ -16,7 +16,6 @@ contract IntegralSwapAdapterTest is Test, ISwapAdapterTypes {
     address constant USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
     address constant USDC_WETH_PAIR = 0x2fe16Dd18bba26e457B7dD2080d5674312b026a2;
     address constant relayerAddress = 0xd17b3c9784510E33cD5B87b490E79253BcD81e2E;
-    bytes32 mockData;
 
     uint256 constant TEST_ITERATIONS = 100;
 
@@ -31,10 +30,7 @@ contract IntegralSwapAdapterTest is Test, ISwapAdapterTypes {
         vm.label(address(USDC_WETH_PAIR), "USDC_WETH_PAIR");
     }
 
-    function testPriceFuzzIntegral(uint256 amount0, uint256 amount1)
-        public
-        view
-    {
+    function testPriceFuzzIntegral(uint256 amount0, uint256 amount1) public {
         bytes32 pair = bytes32(bytes20(USDC_WETH_PAIR));
         uint256[] memory limits = adapter.getLimits(pair, USDC, WETH);
         vm.assume(amount0 < limits[0]);
@@ -87,7 +83,7 @@ contract IntegralSwapAdapterTest is Test, ISwapAdapterTypes {
         uint256 weth_balance_before = IERC20(WETH).balanceOf(address(this));
 
         Trade memory trade =
-            adapter.swap(pair, USDC, WETH, side, specifiedAmount, mockData);
+            adapter.swap(pair, USDC, WETH, side, specifiedAmount);
 
         if (trade.calculatedAmount > 0) {
             if (side == OrderSide.Buy) {
@@ -142,8 +138,7 @@ contract IntegralSwapAdapterTest is Test, ISwapAdapterTypes {
             deal(USDC, address(this), amounts[i]);
             IERC20(USDC).approve(address(adapter), amounts[i]);
 
-            trades[i] =
-                adapter.swap(pair, USDC, WETH, side, amounts[i], mockData);
+            trades[i] = adapter.swap(pair, USDC, WETH, side, amounts[i]);
             vm.revertTo(beforeSwap);
         }
 
@@ -162,14 +157,14 @@ contract IntegralSwapAdapterTest is Test, ISwapAdapterTypes {
         assertEq(res.length, 4);
     }
 
-    function testGetTokensIntegral() public view {
+    function testGetTokensIntegral() public {
         bytes32 pair = bytes32(bytes20(USDC_WETH_PAIR));
         address[] memory tokens = adapter.getTokens(pair);
 
         assertEq(tokens.length, 2);
     }
 
-    function testGetLimitsIntegral() public view {
+    function testGetLimitsIntegral() public {
         bytes32 pair = bytes32(bytes20(USDC_WETH_PAIR));
         uint256[] memory limits = adapter.getLimits(pair, USDC, WETH);
 

--- a/evm/test/UniswapV2SwapAdapter.t.sol
+++ b/evm/test/UniswapV2SwapAdapter.t.sol
@@ -29,7 +29,7 @@ contract UniswapV2PairFunctionTest is AdapterTest {
         vm.label(USDC_WETH_PAIR, "USDC_WETH_PAIR");
     }
 
-    function testPriceFuzz(uint256 amount0, uint256 amount1) public view {
+    function testPriceFuzz(uint256 amount0, uint256 amount1) public {
         bytes32 pair = bytes32(bytes20(USDC_WETH_PAIR));
         uint256[] memory limits = adapter.getLimits(pair, USDC, WETH);
         vm.assume(amount0 < limits[0]);
@@ -47,7 +47,7 @@ contract UniswapV2PairFunctionTest is AdapterTest {
         }
     }
 
-    function testPriceDecreasing() public view {
+    function testPriceDecreasing() public {
         bytes32 pair = bytes32(bytes20(USDC_WETH_PAIR));
         uint256[] memory amounts = new uint256[](TEST_ITERATIONS);
 
@@ -88,7 +88,7 @@ contract UniswapV2PairFunctionTest is AdapterTest {
         uint256 weth_balance = IERC20(WETH).balanceOf(address(this));
 
         Trade memory trade =
-            adapter.swap(pair, USDC, WETH, side, specifiedAmount, mockData);
+            adapter.swap(pair, USDC, WETH, side, specifiedAmount);
 
         if (trade.calculatedAmount > 0) {
             if (side == OrderSide.Buy) {
@@ -133,8 +133,7 @@ contract UniswapV2PairFunctionTest is AdapterTest {
             deal(USDC, address(this), amounts[i]);
             IERC20(USDC).approve(address(adapter), amounts[i]);
 
-            trades[i] =
-                adapter.swap(pair, USDC, WETH, side, amounts[i], mockData);
+            trades[i] = adapter.swap(pair, USDC, WETH, side, amounts[i]);
             vm.revertTo(beforeSwap);
         }
 
@@ -149,16 +148,13 @@ contract UniswapV2PairFunctionTest is AdapterTest {
         executeIncreasingSwaps(OrderSide.Buy);
     }
 
-    function testGetCapabilities(bytes32 pair, address t0, address t1)
-        public
-        view
-    {
+    function testGetCapabilities(bytes32 pair, address t0, address t1) public {
         Capability[] memory res = adapter.getCapabilities(pair, t0, t1);
 
         assertEq(res.length, 4);
     }
 
-    function testGetLimits() public view {
+    function testGetLimits() public {
         bytes32 pair = bytes32(bytes20(USDC_WETH_PAIR));
         uint256[] memory limits = adapter.getLimits(pair, USDC, WETH);
 


### PR DESCRIPTION
Reverts propeller-heads/propeller-protocol-lib#58

because it breaks deploying the SDK. We'll merge this once all components of enabling balancer fee discount are ready (adapter, protosim and defibot)