### PR TITLE
Angle Test Update to meet SDK requirements

### DIFF
--- a/evm/src/angle/AngleAdapter.sol
+++ b/evm/src/angle/AngleAdapter.sol
@@ -28,20 +28,19 @@ contract AngleAdapter is ISwapAdapter {
     }
 
     /// @inheritdoc ISwapAdapter
-    /**
-     * @dev It is not possible to reproduce the swap in a view mode (like
-     * Bancor, Uniswap v2, etc..) as the swap produce a change of storage in
-     * the Angle protocol, that impacts the price post trade. Due to the
-     * architecture of Angle, it's not possible to calculate the storage
-     * modifications of Angle inside the adapter.
-     */
-    function price(bytes32, address, address, uint256[] memory)
-        external
-        pure
-        override
-        returns (Fraction[] memory)
-    {
-        revert NotImplemented("AngleAdapter.price");
+    function price(
+        bytes32,
+        address sellToken,
+        address buyToken,
+        uint256[] memory specifiedAmounts
+    ) external view override returns (Fraction[] memory prices) {
+        prices = new Fraction[](specifiedAmounts.length);
+        uint8 decimals = IERC20Metadata(sellToken).decimals();
+
+        for (uint256 i = 0; i < specifiedAmounts.length; i++) {
+            prices[i] =
+                getPriceAt(sellToken, buyToken, OrderSide.Sell, decimals);
+        }
     }
 
     /// @inheritdoc ISwapAdapter
@@ -145,10 +144,10 @@ contract AngleAdapter is ISwapAdapter {
     {
         address[] memory collateralsAddresses = transmuter.getCollateralList();
         tokens = new address[](collateralsAddresses.length + 1);
+        tokens[0] = transmuter.agToken();
         for (uint256 i = 0; i < collateralsAddresses.length; i++) {
-            tokens[i] = address(collateralsAddresses[i]);
+            tokens[i + 1] = address(collateralsAddresses[i]);
         }
-        tokens[collateralsAddresses.length] = transmuter.agToken();
     }
 
     function getPoolIds(uint256, uint256)
@@ -160,7 +159,7 @@ contract AngleAdapter is ISwapAdapter {
         revert NotImplemented("AngleAdapter.getPoolIds");
     }
 
-    /// @notice Calculates pool prices for specified amounts
+    /// @notice Calculates pool prices after swap
     /// @param tokenIn The token being sold
     /// @param tokenOut The token being bought
     /// @param side Order side
@@ -182,6 +181,23 @@ contract AngleAdapter is ISwapAdapter {
             amountIn = transmuter.quoteOut(amountOut, tokenIn, tokenOut);
         }
         return Fraction(amountOut, amountIn);
+    }
+
+    /// @notice Calculates pool prices for specified amounts (for price
+    /// function)
+    /// @param tokenIn The token being sold
+    /// @param tokenOut The token being bought
+    /// @param specifiedAmount Decimals of the sell token
+    /// @return The price as a fraction corresponding to the provided amount.
+    function getPriceAt(
+        address tokenIn,
+        address tokenOut,
+        uint256 specifiedAmount
+    ) internal view returns (Fraction memory) {
+        return Fraction(
+            transmuter.quoteIn(specifiedAmount, tokenIn, tokenOut),
+            specifiedAmount
+        );
     }
 
     /// @notice Executes a sell order on the contract.

--- a/evm/test/AngleAdapter.t.sol
+++ b/evm/test/AngleAdapter.t.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
+import "./AdapterTest.sol";
 import "forge-std/Test.sol";
 import "openzeppelin-contracts/contracts/interfaces/IERC20.sol";
 import "src/angle/AngleAdapter.sol";
@@ -8,7 +9,7 @@ import "src/interfaces/ISwapAdapterTypes.sol";
 import "src/libraries/FractionMath.sol";
 import "forge-std/console.sol";
 
-contract AngleAdapterTest is Test, ISwapAdapterTypes {
+contract AngleAdapterTest is Test, ISwapAdapterTypes, AdapterTest {
     using FractionMath for Fraction;
 
     AngleAdapter adapter;
@@ -196,5 +197,11 @@ contract AngleAdapterTest is Test, ISwapAdapterTypes {
             adapter.getLimits(pair, address(agEUR), address(EURC));
 
         assertEq(limits.length, 2);
+    }
+
+    function testPoolBehaviourAngle() public {
+        bytes32[] memory poolIds = new bytes32[](1);
+        poolIds[0] = bytes32(0);
+        runPoolBehaviourTest(adapter, poolIds);
     }
 }


### PR DESCRIPTION
This PR includes Angle Adapter Test updates to meet last SDK requirements

Some of the tests applied on price fail, because the price in Angle is dependant on external sources (Oracle), and can therefore be both Constant and Variable depending on time and multiple factors.

To solve this issue, I'd suggest to add a new capability:
Capability.OraclePrice
That, when present, skips some checks on the prices.