### PR TITLE
Integral Test Update to meet SDK Requirements

### DIFF
--- a/evm/test/IntegralSwapAdapter.t.sol
+++ b/evm/test/IntegralSwapAdapter.t.sol
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
+import "./AdapterTest.sol";
 import "forge-std/Test.sol";
 import "openzeppelin-contracts/contracts/interfaces/IERC20.sol";
 import "src/interfaces/ISwapAdapterTypes.sol";
 import "src/libraries/FractionMath.sol";
 import "src/integral/IntegralSwapAdapter.sol";
 
-contract IntegralSwapAdapterTest is Test, ISwapAdapterTypes {
+contract IntegralSwapAdapterTest is Test, ISwapAdapterTypes, AdapterTest {
     using FractionMath for Fraction;
 
     IntegralSwapAdapter adapter;
@@ -182,5 +183,11 @@ contract IntegralSwapAdapterTest is Test, ISwapAdapterTypes {
         limits = new uint256[](2);
         limits[0] = limitMin0;
         limits[1] = limitMin1;
+    }
+
+    function testPoolBehaviourIntegral() public {
+        bytes32[] memory poolIds = new bytes32[](1);
+        poolIds[0] = bytes32(bytes20(USDC_WETH_PAIR));
+        runPoolBehaviourTest(adapter, poolIds);
     }
 }


### PR DESCRIPTION
The following assertion fails:
"Price at limit should be smaller than price at 0"

Because of a bug in AdapterTest.sol:73 :
this assertion should not be here as, if the adapter has the capability ConstantPrice, this assertion may not always be true.