### PR TITLE
Etherfi Test Update to meet SDK Requirements

### DIFF
--- a/evm/test/EtherfiAdapter.t.sol
+++ b/evm/test/EtherfiAdapter.t.sol
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
+import "./AdapterTest.sol";
 import "forge-std/Test.sol";
 import "openzeppelin-contracts/contracts/interfaces/IERC20.sol";
 import "src/interfaces/ISwapAdapterTypes.sol";
 import "src/libraries/FractionMath.sol";
 import "src/etherfi/EtherfiAdapter.sol";
 
-contract EtherfiAdapterTest is Test, ISwapAdapterTypes {
+contract EtherfiAdapterTest is Test, ISwapAdapterTypes, AdapterTest {
     using FractionMath for Fraction;
 
     EtherfiAdapter adapter;
@@ -406,5 +407,11 @@ contract EtherfiAdapterTest is Test, ISwapAdapterTypes {
             adapter.getLimits(pair, address(eEth), address(weEth));
 
         assertEq(limits.length, 2);
+    }
+
+    function testPoolBehaviourEtherfi() public {
+        bytes32[] memory poolIds = new bytes32[](1);
+        poolIds[0] = bytes32(0);
+        runPoolBehaviourTest(adapter, poolIds);
     }
 }


### PR DESCRIPTION
Following functions in AdapterTest.sol: balanceOf, deal and other ERC20-oriented ones fail when input token is address(0) (ETH for Adapters).

Solution:
Add if/else statements checking whether input/output is ether(address(0)) and use:
- address(this).balance - instead of - IERC20(token).balanceOf(address(this))
- deal(address(adapter), amount) - instead of - deal(address(token), address(this), amount)

Other assertions might fail due to precision loss(your priceUnits is ^24 units, maybe too precise considering the price is obtained through divisions of multiple entities for this adapter, please check the getPriceAt), should investigate on these too.