### PR TITLE
fix(evm-compilation): enable via IR

### DIFF
--- a/evm/foundry.toml
+++ b/evm/foundry.toml
@@ -2,6 +2,7 @@
 src = "src"
 out = "out"
 libs = ["lib"]
+via_ir = true
 
 [rpc_endpoints]
 mainnet = "${ETH_RPC_URL}"


### PR DESCRIPTION
This is needed to compile Curve executor.