### PR TITLE
fix(balancer): index `PoolBalanceManaged` balance changes

### DIFF
--- a/substreams/Cargo.lock
+++ b/substreams/Cargo.lock
@@ -222,7 +222,7 @@ dependencies = [
 
 [[package]]
 name = "ethereum-balancer"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "bytes",

--- a/substreams/ethereum-balancer/Cargo.toml
+++ b/substreams/ethereum-balancer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum-balancer"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 
 [lib]

--- a/substreams/ethereum-balancer/src/modules.rs
+++ b/substreams/ethereum-balancer/src/modules.rs
@@ -113,6 +113,17 @@ pub fn map_relative_balances(
                         },
                     ]);
                 }
+            } else if let Some(ev) =
+                abi::vault::events::PoolBalanceManaged::match_and_decode(vault_log.log)
+            {
+                let component_id = format!("0x{}", hex::encode(ev.pool_id));
+                deltas.extend_from_slice(&[BalanceDelta {
+                    ord: vault_log.ordinal(),
+                    tx: Some(vault_log.receipt.transaction.into()),
+                    token: ev.token.to_vec(),
+                    delta: ev.cash_delta.to_signed_bytes_be(),
+                    component_id: component_id.as_bytes().to_vec(),
+                }]);
             }
 
             deltas

--- a/substreams/ethereum-balancer/substreams.yaml
+++ b/substreams/ethereum-balancer/substreams.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: "ethereum_balancer"
-  version: v0.2.1
+  version: v0.2.2
 
 protobuf:
   files:


### PR DESCRIPTION
This PR fixes a bug with pools token balances on Balancer.

We weren't indexing balance changes created by the `PoolBalanceManaged` event