### PR TITLE
fix(balancer): Ignore `PoolBalanceManaged` for not indexed pools

### DIFF
--- a/substreams/Cargo.lock
+++ b/substreams/Cargo.lock
@@ -222,7 +222,7 @@ dependencies = [
 
 [[package]]
 name = "ethereum-balancer-v2"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "bytes",

--- a/substreams/ethereum-balancer-v2/Cargo.toml
+++ b/substreams/ethereum-balancer-v2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum-balancer-v2"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 
 [lib]

--- a/substreams/ethereum-balancer-v2/src/modules.rs
+++ b/substreams/ethereum-balancer-v2/src/modules.rs
@@ -122,13 +122,18 @@ pub fn map_relative_balances(
                 abi::vault::events::PoolBalanceManaged::match_and_decode(vault_log.log)
             {
                 let component_id = format!("0x{}", hex::encode(ev.pool_id));
-                deltas.extend_from_slice(&[BalanceDelta {
-                    ord: vault_log.ordinal(),
-                    tx: Some(vault_log.receipt.transaction.into()),
-                    token: ev.token.to_vec(),
-                    delta: ev.cash_delta.to_signed_bytes_be(),
-                    component_id: component_id.as_bytes().to_vec(),
-                }]);
+                if store
+                    .get_last(format!("pool:{}", &component_id[..42]))
+                    .is_some()
+                {
+                    deltas.extend_from_slice(&[BalanceDelta {
+                        ord: vault_log.ordinal(),
+                        tx: Some(vault_log.receipt.transaction.into()),
+                        token: ev.token.to_vec(),
+                        delta: ev.cash_delta.to_signed_bytes_be(),
+                        component_id: component_id.as_bytes().to_vec(),
+                    }]);
+                }
             }
 
             deltas

--- a/substreams/ethereum-balancer-v2/substreams.yaml
+++ b/substreams/ethereum-balancer-v2/substreams.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: "ethereum_balancer_v2"
-  version: v0.2.3
+  version: v0.2.4
 
 protobuf:
   files:


### PR DESCRIPTION
This PR fixes a bug where we would index balances delta for unknown pools.