### PR TITLE
[DO NOT MERGE] Replicate getLimits call in rust that hangs.

### DIFF
--- a/evm/test/BalancerV2SwapAdapter.t.sol
+++ b/evm/test/BalancerV2SwapAdapter.t.sol
@@ -25,7 +25,8 @@ contract BalancerV2SwapAdapterTest is AdapterTest {
     uint256 constant TEST_ITERATIONS = 100;
 
     function setUp() public {
-        uint256 forkBlock = 18710000;
+        // Block before we tried to get limits
+        uint256 forkBlock = 21187292;
         vm.createSelectFork(vm.rpcUrl("mainnet"), forkBlock);
 
         adapter = new BalancerV2SwapAdapter(payable(address(balancerV2Vault)));
@@ -35,6 +36,21 @@ contract BalancerV2SwapAdapterTest is AdapterTest {
         vm.label(address(WETH), "WETH");
         vm.label(BAL, "BAL");
         vm.label(address(B_80BAL_20WETH), "B_80BAL_20WETH");
+
+        // Set storage overrides for BAL token
+        bytes32 balSlot = bytes32(uint256(24060209162895628919861412957428278191632570471602070876674374646072182449944));
+        vm.store(BAL, balSlot, bytes32(uint256(71285870430468465766552848)));
+
+        // Set storage overrides for WETH token
+        bytes32 wethSlot1 = bytes32(uint256(24060209162895628919861412957428278191632570471602070876674374646072182449944));
+        vm.store(WETH, wethSlot1, bytes32(uint256(1423822402467431679410)));
+
+        bytes32 wethSlot2 = bytes32(uint256(58546993237423525698686728856645416951692145960565761888391937184176623942864));
+        vm.store(WETH, wethSlot2, bytes32(uint256(578960446186580977117854925043439539266349923328202820197287920039565648199)));
+
+        bytes32 wethSlot3 = bytes32(uint256(110136159478993350616340414857413728709904511599989695046923576775517543504731));
+        vm.store(WETH, wethSlot3, bytes32(uint256(578960446186580977117854925043439539266349923328202820197287920039565648199)));
+
     }
 
     function testPrice() public {
@@ -193,13 +209,13 @@ contract BalancerV2SwapAdapterTest is AdapterTest {
         }
     }
 
-    function testGetLimits() public view {
-        uint256[] memory limits =
-            adapter.getLimits(B_80BAL_20WETH_POOL_ID, BAL, WETH);
+    function testGetLimits() public {
+        (bool success, bytes memory limits) = address(adapter).call
+            (hex"a9270fbe9232a548dd9e81bac65500b5e0d918f8ba93675c000200000000000000000423000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2000000000000000000000000fd0205066521550d7d7ab19da8f72bb004b4c341");
 
-        assert(limits.length == 2);
-        assert(limits[0] > 0);
-        assert(limits[1] > 0);
+        assert(success);
+        console.logBool(success);
+        console.logBytes(limits);
     }
 
     function testGetCapabilitiesFuzz(bytes32 pool, address t0, address t1)


### PR DESCRIPTION
```
Traces:
  [35870] BalancerV2SwapAdapterTest::testGetLimits()
    ├─ [26532] BalancerV2SwapAdapter::getLimits(0x9232a548dd9e81bac65500b5e0d918f8ba93675c000200000000000000000423, WETH: [0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2], 0xfd0205066521550D7d7AB19DA8F72bb004b4C341)
    │   ├─ [2927] IVault::getPool(0x9232a548dd9e81bac65500b5e0d918f8ba93675c000200000000000000000423) [staticcall]
    │   │   └─ ← [Return] 0x9232a548DD9E81BaC65500b5e0d918F8Ba93675C, 2
    │   ├─ [271] 0x9232a548DD9E81BaC65500b5e0d918F8Ba93675C::getBptIndex() [staticcall]
    │   │   └─ ← [Revert] EvmError: Revert
    │   ├─ [271] 0x9232a548DD9E81BaC65500b5e0d918F8Ba93675C::getActualSupply() [staticcall]
    │   │   └─ ← [Revert] EvmError: Revert
    │   ├─ [269] 0x9232a548DD9E81BaC65500b5e0d918F8Ba93675C::getVirtualSupply() [staticcall]
    │   │   └─ ← [Revert] EvmError: Revert
    │   ├─ [13081] IVault::getPoolTokens(0x9232a548dd9e81bac65500b5e0d918f8ba93675c000200000000000000000423) [staticcall]
    │   │   └─ ← [Return] [0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2, 0xfd0205066521550D7d7AB19DA8F72bb004b4C341], [237686920387949633593 [2.376e20], 130506897225056594977070079 [1.305e26]], 21186975 [2.118e7]
    │   └─ ← [Return] [71306076116384890077 [7.13e19], 39152069167516978493121023 [3.915e25]]
    ├─ [0] console::log(true) [staticcall]
    │   └─ ← [Stop] 
    ├─ [0] console::logBytes(0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000003dd92126e9c163cdd0000000000000000000000000000000000000000002062c5ec24c7e9c0e1e1ff) [staticcall]
    │   └─ ← [Stop] 
    └─ ← [Return] 

Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 456.65ms (1.24ms CPU time)
```