### PR TITLE
fix: address missed repo renaming

### DIFF
--- a/.github/workflows/swap-encoders.yaml
+++ b/.github/workflows/swap-encoders.yaml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   tests:
-    uses: propeller-heads/propeller-protocol-lib/.github/workflows/python-tests.yaml@main
+    uses: propeller-heads/tycho-protocol-sdk/.github/workflows/python-tests.yaml@main
 
   formatting:
     name: Formatting

--- a/docs/indexing/getting-started.md
+++ b/docs/indexing/getting-started.md
@@ -37,7 +37,7 @@ In the following section, we outline the typical procedure for structuring an in
 Commonly, protocols employ factory contracts to deploy a contract for each swap component (also known as a pool or pair). We will explain how to efficiently index this system of contracts. It's important to note, however, that the techniques described below are broadly applicable, even if a protocol deviates from this specific pattern it should be possible to index it and emit the required messages.
 
 {% hint style="info" %}
-The following examples and code snippets have been taken from the ethereum-balancer substream. The complete code is available [here](https://github.com/propeller-heads/propeller-protocol-lib/tree/main/substreams/ethereum-balancer).
+The following examples and code snippets have been taken from the ethereum-balancer substream. The complete code is available [here](https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/substreams/ethereum-balancer-v2).
 {% endhint %}
 
 Usually an integration consists of the following modules:

--- a/docs/indexing/overview.md
+++ b/docs/indexing/overview.md
@@ -16,7 +16,7 @@ Next, for each emitted transactions that carries state changes, the correspondin
 
 So basically when processing a block we need to emit the block itself, all transactions that introduced protocol state changes and last but not least the state changes themselves, associated to their corresponding transaction.
 
-**The data model that encodes changes, transaction and blocks in messages, can be found** [**here**](https://github.com/propeller-heads/propeller-protocol-lib/tree/main/proto/tycho/evm/v1)**.**&#x20;
+**The data model that encodes changes, transaction and blocks in messages, can be found** [**here**](https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/proto/tycho/evm/v1)**.**&#x20;
 
 #### Models
 
@@ -24,7 +24,7 @@ The models below are used for communication between Substreams and Tycho indexer
 
 Our indexer expects to receive a `BlockChanges` output from your Substreams package.
 
-{% @github-files/github-code-block url="https://github.com/propeller-heads/propeller-protocol-lib/blob/main/proto/tycho/evm/v1/common.proto" %}
+{% @github-files/github-code-block url="https://github.com/propeller-heads/tycho-protocol-sdk/blob/main/proto/tycho/evm/v1/common.proto" %}
 
 Please be aware that changes need to be aggregated on the transaction level, it is considered an error to emit `BlockChanges` with duplicated transactions present in the `changes` attributes.
 

--- a/docs/indexing/vm-integration/README.md
+++ b/docs/indexing/vm-integration/README.md
@@ -34,7 +34,7 @@ We have integrated the **Balancer** protocol as a reference, see `/substreams/et
 
 1. Start by making a local copy of the Propeller Protocol Lib repository:
     ```bash
-    git clone https://github.com/propeller-heads/propeller-protocol-lib
+    git clone https://github.com/propeller-heads/tycho-protocol-sdk
     ```
 
 ## Understanding the Substreams VM integration

--- a/docs/logic/vm-integration/README.md
+++ b/docs/logic/vm-integration/README.md
@@ -29,12 +29,12 @@ Following exchanges have been integrated using VM approach:
 2.  Start by making a local copy of the Propeller Protocol Lib repository:
 
     ```bash
-    git clone https://github.com/propeller-heads/propeller-protocol-lib
+    git clone https://github.com/propeller-heads/tycho-protocol-sdk
     ```
 3.  Install forge dependencies:
 
     ```bash
-    cd ./propeller-protocol-lib/evm/
+    cd ./tycho-protocol-sdk/evm/
     forge install
     ```
 

--- a/docs/logic/vm-integration/ethereum-solidity.md
+++ b/docs/logic/vm-integration/ethereum-solidity.md
@@ -6,7 +6,7 @@ description: Provide protocol logic using the ethereum virtual machine
 
 ## Swap/exchange protocol
 
-To integrate an EVM exchange protocol the [ISwapAdapter.sol ](https://github.com/propeller-heads/propeller-protocol-lib/blob/main/evm/interfaces/ISwapAdapter.sol)should be implemented. Additionally, a manifest file is required that summarises some metadata about the protocol.
+To integrate an EVM exchange protocol the [ISwapAdapter.sol ](https://github.com/propeller-heads/tycho-protocol-sdk/blob/main/evm/interfaces/ISwapAdapter.sol)should be implemented. Additionally, a manifest file is required that summarises some metadata about the protocol.
 
 {% hint style="info" %}
 Although the interface is specified for Solidity, you are not limited to writing the adapter contract in Solidity. We can use any compiled evm bytecode. So if you prefer e.g. Vyper, you are welcome to implement the interface using Vyper. Unfortunately we do not provide all the tooling for Vyper contracts yet, but you can certainly submit compiled Vyper byte code.

--- a/propeller-swap-encoders/pyproject.toml
+++ b/propeller-swap-encoders/pyproject.toml
@@ -31,5 +31,5 @@ testing = [
 ]
 
 [project.urls]
-homepage = "https://github.com/propeller-heads/propeller-protocol-lib"
+homepage = "https://github.com/propeller-heads/tycho-protocol-sdk"
 

--- a/testing/README.md
+++ b/testing/README.md
@@ -47,7 +47,7 @@ The script to generate this file manually is available under `evm/scripts/buildR
 ### Step 2: Create python virtual environment for testing
 
 Run setup env script. It will create a conda virtual env and install all dependencies.
-This script must be run from within the `propeller-protocol-lib/testing` directory.
+This script must be run from within the `tycho-protocol-sdk/testing` directory.
 
 Please note that some dependencies require access to our private PyPI repository.
 
@@ -100,7 +100,7 @@ python ./testing/src/runner/cli.py --package "your-package-name"
 If you want to run tests for `ethereum-balancer-v2`, use:
 
 ```bash
-conda activate propeller-protocol-lib-testing
+conda activate tycho-protocol-sdk-testing
 export RPC_URL="https://ethereum-mainnet.core.chainstack.com/123123123123"
 export SUBSTREAMS_API_TOKEN=eyJhbGci...
 docker compose up -d db

--- a/testing/setup_env.sh
+++ b/testing/setup_env.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Variables
-ENV_NAME="propeller-protocol-lib-testing"
+ENV_NAME="tycho-protocol-sdk-testing"
 PYTHON_VERSION="3.9"
 REQUIREMENTS_FILE="requirements.txt"
 


### PR DESCRIPTION
This updated:
- workflow urls (CI should run again now)
- docs links
- repo project urls