### PR TITLE
refactor(substreams): remove workspace dependencies

### DIFF
--- a/substreams/Cargo.lock
+++ b/substreams/Cargo.lock
@@ -236,7 +236,7 @@ dependencies = [
  "prost-types 0.12.6",
  "substreams",
  "substreams-ethereum",
- "tycho-substreams",
+ "tycho-substreams 0.2.0 (git+https://github.com/propeller-heads/tycho-protocol-sdk.git?rev=b8aeaa3)",
 ]
 
 [[package]]
@@ -257,7 +257,7 @@ dependencies = [
  "serde_qs",
  "substreams",
  "substreams-ethereum",
- "tycho-substreams",
+ "tycho-substreams 0.2.0 (git+https://github.com/propeller-heads/tycho-protocol-sdk.git?rev=b8aeaa3)",
 ]
 
 [[package]]
@@ -277,7 +277,7 @@ dependencies = [
  "regex",
  "substreams",
  "substreams-ethereum",
- "tycho-substreams",
+ "tycho-substreams 0.2.0 (git+https://github.com/propeller-heads/tycho-protocol-sdk.git?rev=b8aeaa3)",
 ]
 
 [[package]]
@@ -297,7 +297,7 @@ dependencies = [
  "regex",
  "substreams",
  "substreams-ethereum",
- "tycho-substreams",
+ "tycho-substreams 0.2.0 (git+https://github.com/propeller-heads/tycho-protocol-sdk.git?rev=b8aeaa3)",
 ]
 
 [[package]]
@@ -343,8 +343,8 @@ dependencies = [
  "serde_qs",
  "substreams",
  "substreams-ethereum",
- "substreams-helper",
- "tycho-substreams",
+ "substreams-helper 0.0.2 (git+https://github.com/propeller-heads/tycho-protocol-sdk.git?rev=b8aeaa3)",
+ "tycho-substreams 0.2.0 (git+https://github.com/propeller-heads/tycho-protocol-sdk.git?rev=b8aeaa3)",
 ]
 
 [[package]]
@@ -362,9 +362,9 @@ dependencies = [
  "substreams",
  "substreams-entity-change",
  "substreams-ethereum",
- "substreams-helper",
+ "substreams-helper 0.0.2 (git+https://github.com/propeller-heads/tycho-protocol-sdk.git?rev=b8aeaa3)",
  "tiny-keccak",
- "tycho-substreams",
+ "tycho-substreams 0.2.0 (git+https://github.com/propeller-heads/tycho-protocol-sdk.git?rev=b8aeaa3)",
 ]
 
 [[package]]
@@ -1141,7 +1141,7 @@ dependencies = [
  "substreams",
  "substreams-ethereum",
  "tiny-keccak",
- "tycho-substreams",
+ "tycho-substreams 0.2.0 (git+https://github.com/propeller-heads/tycho-protocol-sdk.git?rev=b8aeaa3)",
 ]
 
 [[package]]
@@ -1190,14 +1190,37 @@ dependencies = [
  "substreams",
  "substreams-entity-change",
  "substreams-ethereum",
- "substreams-helper",
+ "substreams-helper 0.0.2 (git+https://github.com/propeller-heads/tycho-protocol-sdk.git?rev=b8aeaa3)",
  "tiny-keccak",
- "tycho-substreams",
+ "tycho-substreams 0.2.0 (git+https://github.com/propeller-heads/tycho-protocol-sdk.git?rev=b8aeaa3)",
 ]
 
 [[package]]
 name = "substreams-helper"
 version = "0.0.2"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bigdecimal",
+ "downcast-rs",
+ "ethabi 18.0.0",
+ "hex",
+ "hex-literal 0.4.1",
+ "num-bigint",
+ "pad",
+ "prost 0.11.9",
+ "prost-types 0.12.6",
+ "substreams",
+ "substreams-entity-change",
+ "substreams-ethereum",
+ "thiserror",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "substreams-helper"
+version = "0.0.2"
+source = "git+https://github.com/propeller-heads/tycho-protocol-sdk.git?rev=b8aeaa3#b8aeaa3dc6e7242a5dd23681921258ef2cb3c6dd"
 dependencies = [
  "anyhow",
  "base64",
@@ -1318,6 +1341,22 @@ dependencies = [
 [[package]]
 name = "tycho-substreams"
 version = "0.2.0"
+dependencies = [
+ "ethabi 18.0.0",
+ "hex",
+ "itertools 0.12.1",
+ "num-bigint",
+ "prost 0.11.9",
+ "serde",
+ "serde_json",
+ "substreams",
+ "substreams-ethereum",
+]
+
+[[package]]
+name = "tycho-substreams"
+version = "0.2.0"
+source = "git+https://github.com/propeller-heads/tycho-protocol-sdk.git?rev=b8aeaa3#b8aeaa3dc6e7242a5dd23681921258ef2cb3c6dd"
 dependencies = [
  "ethabi 18.0.0",
  "hex",

--- a/substreams/Cargo.toml
+++ b/substreams/Cargo.toml
@@ -13,21 +13,6 @@ members = [
 ]
 resolver = "2"
 
-
-[workspace.dependencies]
-substreams-ethereum = "0.9.9"
-substreams = "0.5.22"
-prost = "0.11"
-prost-types = "0.12.3"
-hex-literal = "0.4.1"
-anyhow = "1.0.75"
-hex = "0.4.3"
-ethabi = "18.0.0"
-tycho-substreams = { path = "crates/tycho-substreams" }
-substreams-helper = { path = "crates/substreams-helper" }
-serde = "1.0.204"
-serde_json = "1.0.120"
-
 [profile.release]
 lto = true
 opt-level = 's'

--- a/substreams/crates/substreams-helper/Cargo.toml
+++ b/substreams/crates/substreams-helper/Cargo.toml
@@ -8,17 +8,17 @@ homepage = "https://messari.io/"
 repository = "https://github.com/messari/substreams/substreams-helper"
 
 [dependencies]
-ethabi.workspace = true
-hex.workspace = true
-hex-literal.workspace = true
-prost.workspace = true
-prost-types.workspace = true
+ethabi = "18.0.0"
+hex = "0.4.3"
+hex-literal = "0.4.1"
+prost = "0.11"
+prost-types = "0.12.3"
 num-bigint = "0.4"
 bigdecimal = "0.3"
 pad = "0.1"
 tiny-keccak = { version = "2.0", features = ["keccak"] }
-substreams = { workspace = true }
-substreams-ethereum = { workspace = true }
+substreams = "0.5.22"
+substreams-ethereum = "0.9.9"
 thiserror = "1.0.37"
 downcast-rs = "1.2.0"
 substreams-entity-change = "1.1.0"
@@ -26,4 +26,4 @@ base64 = "0.13.0"
 
 
 [build-dependencies]
-anyhow.workspace = true
+anyhow = "1.0.75"

--- a/substreams/crates/tycho-substreams/Cargo.toml
+++ b/substreams/crates/tycho-substreams/Cargo.toml
@@ -4,12 +4,12 @@ version = "0.2.0"
 edition = "2021"
 
 [dependencies]
-substreams-ethereum.workspace = true
-substreams.workspace = true
-prost.workspace = true
-hex.workspace = true
+substreams-ethereum = "0.9.9"
+substreams = "0.5.22"
+prost = "0.11"
+hex = "0.4.3"
 itertools = "0.12.0"
-ethabi.workspace = true
+ethabi = "18.0.0"
 num-bigint = "0.4.4"
-serde.workspace = true
-serde_json.workspace = true
+serde = "1.0.204"
+serde_json = "1.0.120"

--- a/substreams/ethereum-ambient/Cargo.toml
+++ b/substreams/ethereum-ambient/Cargo.toml
@@ -8,15 +8,15 @@ name = "substreams_ethereum_ambient"
 crate-type = ["cdylib"]
 
 [dependencies]
-tycho-substreams.workspace = true
-substreams.workspace = true
-substreams-ethereum.workspace = true
-prost.workspace = true
-hex-literal.workspace = true
-ethabi.workspace = true
-hex.workspace = true
+tycho-substreams = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", rev = "b8aeaa3" }
+substreams = "0.5.22"
+substreams-ethereum = "0.9.9"
+prost = "0.11"
+hex-literal = "0.4.1"
+ethabi = "18.0.0"
+hex = "0.4.3"
 bytes = "1.5.0"
-anyhow.workspace = true
+anyhow = "1.0.75"
 tiny-keccak = "2.0.2"
 num-bigint = { version = "0.4.4", features = [] }
 quote = "1.0.33"

--- a/substreams/ethereum-balancer-v2/Cargo.toml
+++ b/substreams/ethereum-balancer-v2/Cargo.toml
@@ -8,18 +8,18 @@ name = "ethereum_balancer_v2"
 crate-type = ["cdylib"]
 
 [dependencies]
-substreams.workspace = true
-substreams-ethereum.workspace = true
-prost.workspace = true
-prost-types.workspace = true
-hex-literal.workspace = true
-ethabi.workspace = true
-hex.workspace = true
+substreams = "0.5.22"
+substreams-ethereum = "0.9.9"
+prost = "0.11"
+prost-types = "0.12.3"
+hex-literal = "0.4.1"
+ethabi = "18.0.0"
+hex = "0.4.3"
 bytes = "1.5.0"
 anyhow = "1.0.75"
 num-bigint = "0.4.4"
 itertools = "0.12.0"
-tycho-substreams.workspace = true
+tycho-substreams = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", rev = "b8aeaa3" }
 
 [build-dependencies]
 anyhow = "1"

--- a/substreams/ethereum-curve/Cargo.toml
+++ b/substreams/ethereum-curve/Cargo.toml
@@ -8,17 +8,17 @@ name = "ethereum_curve"
 crate-type = ["cdylib"]
 
 [dependencies]
-substreams.workspace = true
-substreams-ethereum.workspace = true
-prost.workspace = true
-prost-types.workspace = true
-hex-literal.workspace = true
-ethabi.workspace = true
-hex.workspace = true
+substreams = "0.5.22"
+substreams-ethereum = "0.9.9"
+prost = "0.11"
+prost-types = "0.12.3"
+hex-literal = "0.4.1"
+ethabi = "18.0.0"
+hex = "0.4.3"
 bytes = "1.5.0"
 anyhow = "1.0.75"
 num-bigint = "0.4.4"
-tycho-substreams.workspace = true
+tycho-substreams = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", rev = "b8aeaa3" }
 serde = { version = "1.0", features = ["derive"] }
 serde_qs = "0.13.0"
 itertools = "0.13.0"

--- a/substreams/ethereum-sfrax/Cargo.toml
+++ b/substreams/ethereum-sfrax/Cargo.toml
@@ -9,15 +9,15 @@ crate-type = ["cdylib"]
 
 [dependencies]
 ethabi = "17"
-hex-literal.workspace = true
+hex-literal = "0.4.1"
 num-bigint = "0.4"
 num-traits = "0.2.15"
-prost.workspace = true
+prost = "0.11"
 prost-types = "0.11"
-substreams.workspace = true
-substreams-ethereum.workspace = true
-hex.workspace = true
-tycho-substreams.workspace = true
+substreams = "0.5.22"
+substreams-ethereum = "0.9.9"
+hex = "0.4.3"
+tycho-substreams = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", rev = "b8aeaa3" }
 itertools = "0.12.0"
 anyhow = "1.0.75"
 

--- a/substreams/ethereum-sfraxeth/Cargo.toml
+++ b/substreams/ethereum-sfraxeth/Cargo.toml
@@ -9,15 +9,15 @@ crate-type = ["cdylib"]
 
 [dependencies]
 ethabi = "17"
-hex-literal.workspace = true
+hex-literal = "0.4.1"
 num-bigint = "0.4"
 num-traits = "0.2.15"
-prost.workspace = true
+prost = "0.11"
 prost-types = "0.11"
-substreams.workspace = true
-substreams-ethereum.workspace = true
-hex.workspace = true
-tycho-substreams.workspace = true
+substreams = "0.5.22"
+substreams-ethereum = "0.9.9"
+hex = "0.4.3"
+tycho-substreams = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", rev = "b8aeaa3" }
 itertools = "0.12.0"
 anyhow = "1.0.75"
 

--- a/substreams/ethereum-template/Cargo.toml
+++ b/substreams/ethereum-template/Cargo.toml
@@ -8,7 +8,7 @@ name = "ethereum_template"
 crate-type = ["cdylib"]
 
 [dependencies]
-substreams.workspace = true
-substreams-ethereum.workspace = true
-prost.workspace = true
-tycho-substreams.workspace = true
+substreams = "0.5.22"
+substreams-ethereum = "0.9.9"
+prost = "0.11"
+tycho-substreams = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", rev = "b8aeaa3" }

--- a/substreams/ethereum-uniswap-v2/Cargo.toml
+++ b/substreams/ethereum-uniswap-v2/Cargo.toml
@@ -8,22 +8,22 @@ name = "ethereum_uniswap_v2"
 crate-type = ["cdylib"]
 
 [dependencies]
-substreams.workspace = true
-substreams-ethereum.workspace = true
-prost.workspace = true
-ethabi.workspace = true
-anyhow = { workspace = true, features = [] }
-hex-literal.workspace = true
-substreams-helper.workspace = true
-tycho-substreams.workspace = true
+substreams = "0.5.22"
+substreams-ethereum = "0.9.9"
+prost = "0.11"
+ethabi = "18.0.0"
+anyhow = "1.0.75"
+hex-literal = "0.4.1"
+substreams-helper = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", rev = "b8aeaa3" }
+tycho-substreams = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", rev = "b8aeaa3" }
 num-bigint = "0.4.4"
 itertools = "0.12.1"
 serde_qs = "0.13.0"
-serde.workspace = true
+serde = "1.0.204"
 
 [target.wasm32-unknown-unknown.dependencies]
 getrandom = { version = "0.2", features = ["custom"] }
 
 [build-dependencies]
-anyhow.workspace = true
-substreams-ethereum.workspace = true
+anyhow = "1.0.75"
+substreams-ethereum = "0.9.9"

--- a/substreams/ethereum-uniswap-v3-logs-only/Cargo.toml
+++ b/substreams/ethereum-uniswap-v3-logs-only/Cargo.toml
@@ -8,16 +8,16 @@ name = "ethereum_uniswap_v3_logs_only"
 crate-type = ["cdylib"]
 
 [dependencies]
-substreams.workspace = true
-substreams-ethereum.workspace = true
-prost.workspace = true
-ethabi.workspace = true
-anyhow = { workspace = true, features = [] }
-hex-literal.workspace = true
-substreams-helper.workspace = true
-tycho-substreams.workspace = true
+substreams = "0.5.22"
+substreams-ethereum = "0.9.9"
+prost = "0.11"
+ethabi = "18.0.0"
+anyhow = "1.0.75"
+hex-literal = "0.4.1"
+substreams-helper = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", rev = "b8aeaa3" }
+tycho-substreams = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", rev = "b8aeaa3" }
 num-bigint = "0.4.4"
-hex.workspace = true
+hex = "0.4.3"
 tiny-keccak = "2.0"
 substreams-entity-change = "1.3"
 itertools = "0.13.0"
@@ -26,5 +26,5 @@ itertools = "0.13.0"
 getrandom = { version = "0.2", features = ["custom"] }
 
 [build-dependencies]
-anyhow.workspace = true
-substreams-ethereum.workspace = true
+anyhow = "1.0.75"
+substreams-ethereum = "0.9.9"

--- a/substreams/ethereum-uniswap-v3/Cargo.toml
+++ b/substreams/ethereum-uniswap-v3/Cargo.toml
@@ -8,16 +8,16 @@ name = "substreams_ethereum_uniswap_v3"
 crate-type = ["cdylib"]
 
 [dependencies]
-substreams.workspace = true
-substreams-ethereum.workspace = true
-prost.workspace = true
-ethabi.workspace = true
-anyhow = { workspace = true, features = [] }
-hex-literal.workspace = true
-substreams-helper.workspace = true
-tycho-substreams.workspace = true
+substreams = "0.5.22"
+substreams-ethereum = "0.9.9"
+prost = "0.11"
+ethabi = "18.0.0"
+anyhow = "1.0.75"
+hex-literal = "0.4.1"
+substreams-helper = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", rev = "b8aeaa3" }
+tycho-substreams = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", rev = "b8aeaa3" }
 num-bigint = "0.4.4"
-hex.workspace = true
+hex = "0.4.3"
 tiny-keccak = "2.0"
 substreams-entity-change = "1.3"
 
@@ -25,5 +25,5 @@ substreams-entity-change = "1.3"
 getrandom = { version = "0.2", features = ["custom"] }
 
 [build-dependencies]
-anyhow.workspace = true
-substreams-ethereum.workspace = true
+anyhow = "1.0.75"
+substreams-ethereum = "0.9.9"


### PR DESCRIPTION
This is to make each substreams completely independent, before when we would need a new version of a dependency, we would have to change it for every crate which would lead to a change of every substreams module hash. We want to make every Substreams completely independant and frozen, this also helps to maintain a correct versionning.