### PR TITLE
fix(uniswap-v4): miscellaneous fixes for UniswapV4

### DIFF
--- a/substreams/Cargo.lock
+++ b/substreams/Cargo.lock
@@ -369,7 +369,7 @@ dependencies = [
 
 [[package]]
 name = "ethereum-uniswap-v4"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "ethabi 18.0.0",

--- a/substreams/Cargo.lock
+++ b/substreams/Cargo.lock
@@ -379,6 +379,7 @@ dependencies = [
  "itertools 0.13.0",
  "num-bigint",
  "prost 0.11.9",
+ "rstest",
  "substreams",
  "substreams-entity-change",
  "substreams-ethereum",
@@ -430,6 +431,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-core",
+ "futures-macro",
+ "futures-task",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -449,6 +493,12 @@ dependencies = [
  "libc",
  "wasi",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "hashbrown"
@@ -755,6 +805,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -978,6 +1040,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
 name = "rlp"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -988,10 +1056,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "rstest"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03e905296805ab93e13c1ec3a03f4b6c4f35e9498a3d5fa96dc626d22c03cd89"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef0053bbffce09062bee4bcc499b0fbe7a57b879f1efe088d6d8d4c7adcdef9b"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn 2.0.90",
+ "unicode-ident",
+]
+
+[[package]]
 name = "rustc-hex"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -1011,6 +1118,12 @@ name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
+name = "semver"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
 
 [[package]]
 name = "serde"
@@ -1074,6 +1187,15 @@ checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
  "digest",
  "keccak",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]

--- a/substreams/ethereum-uniswap-v4/Cargo.toml
+++ b/substreams/ethereum-uniswap-v4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum-uniswap-v4"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [lib]

--- a/substreams/ethereum-uniswap-v4/Cargo.toml
+++ b/substreams/ethereum-uniswap-v4/Cargo.toml
@@ -22,6 +22,9 @@ tiny-keccak = "2.0"
 substreams-entity-change = "1.3"
 itertools = "0.13.0"
 
+[dev-dependencies]
+rstest = "0.24.0"
+
 [target.wasm32-unknown-unknown.dependencies]
 getrandom = { version = "0.2", features = ["custom"] }
 

--- a/substreams/ethereum-uniswap-v4/ethereum-uniswap-v4.yaml
+++ b/substreams/ethereum-uniswap-v4/ethereum-uniswap-v4.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: "ethereum_uniswap_v4"
-  version: v0.1.0
+  version: v0.1.1
 
 protobuf:
   files:
@@ -81,7 +81,7 @@ modules:
     valueType: bigint
     inputs:
       - map: map_balance_changes
-  
+
   - name: map_ticks_changes
     kind: map
     initialBlock: 21688329
@@ -97,7 +97,7 @@ modules:
     valueType: bigint
     inputs:
       - map: map_ticks_changes
-  
+
   - name: map_liquidity_changes
     kind: map
     initialBlock: 21688329
@@ -133,6 +133,6 @@ modules:
         mode: deltas
     output:
       type: proto:tycho.evm.v1.BlockChanges
-      
+
 params:
   map_pools_created: "000000000004444c5dc75cB358380D2e3dE08A90"

--- a/substreams/ethereum-uniswap-v4/ethereum-uniswap-v4.yaml
+++ b/substreams/ethereum-uniswap-v4/ethereum-uniswap-v4.yaml
@@ -56,13 +56,21 @@ modules:
     valueType: int64
     inputs:
       - map: map_events
-  
+
+  - name: store_pool_current_sqrt_price
+    kind: store
+    initialBlock: 21688329
+    updatePolicy: set
+    valueType: bigint
+    inputs:
+      - map: map_events
+
   - name: map_balance_changes
     kind: map
     initialBlock: 21688329
     inputs:
       - map: map_events
-      - store: store_pool_current_tick
+      - store: store_pool_current_sqrt_price
     output:
       type: proto:tycho.evm.v1.BlockBalanceDeltas
 

--- a/substreams/ethereum-uniswap-v4/sepolia-uniswap-v4.yaml
+++ b/substreams/ethereum-uniswap-v4/sepolia-uniswap-v4.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: "ethereum_uniswap_v4"
-  version: v0.1.0
+  version: v0.1.1
 
 protobuf:
   files:
@@ -56,13 +56,21 @@ modules:
     valueType: int64
     inputs:
       - map: map_events
-  
+
+  - name: store_pool_current_sqrt_price
+    kind: store
+    initialBlock: 6894393
+    updatePolicy: set
+    valueType: bigint
+    inputs:
+      - map: map_events
+
   - name: map_balance_changes
     kind: map
     initialBlock: 6894393
     inputs:
       - map: map_events
-      - store: store_pool_current_tick
+      - store: store_pool_current_sqrt_price
     output:
       type: proto:tycho.evm.v1.BlockBalanceDeltas
 

--- a/substreams/ethereum-uniswap-v4/src/modules/4_store_current_sqrtprice.rs
+++ b/substreams/ethereum-uniswap-v4/src/modules/4_store_current_sqrtprice.rs
@@ -17,7 +17,7 @@ pub fn store_pool_current_sqrt_price(events: Events, store: StoreSetBigInt) {
         .into_iter()
         .filter_map(event_to_current_sqrt_price)
         .for_each(|(pool, ordinal, new_tick_index)| {
-            store.set(ordinal, format!("pool:{0}", pool), &new_tick_index.into())
+            store.set(ordinal, format!("pool:{0}", pool), &new_tick_index)
         });
 }
 

--- a/substreams/ethereum-uniswap-v4/src/modules/4_store_current_sqrtprice.rs
+++ b/substreams/ethereum-uniswap-v4/src/modules/4_store_current_sqrtprice.rs
@@ -1,0 +1,39 @@
+use substreams::{
+    scalar::BigInt,
+    store::{StoreSet, StoreSetBigInt},
+};
+
+use crate::pb::uniswap::v4::{
+    events::{pool_event, PoolEvent},
+    Events,
+};
+
+use substreams::store::StoreNew;
+
+#[substreams::handlers::store]
+pub fn store_pool_current_sqrt_price(events: Events, store: StoreSetBigInt) {
+    events
+        .pool_events
+        .into_iter()
+        .filter_map(event_to_current_sqrt_price)
+        .for_each(|(pool, ordinal, new_tick_index)| {
+            store.set(ordinal, format!("pool:{0}", pool), &new_tick_index.into())
+        });
+}
+
+fn event_to_current_sqrt_price(event: PoolEvent) -> Option<(String, u64, BigInt)> {
+    match event.r#type.as_ref().unwrap() {
+        pool_event::Type::Initialize(initialize) => Some((
+            event.pool_id,
+            event.log_ordinal,
+            BigInt::try_from(&initialize.sqrt_price_x96)
+                .expect("cannot convert sqrt_price to bigint"),
+        )),
+        pool_event::Type::Swap(swap) => Some((
+            event.pool_id,
+            event.log_ordinal,
+            BigInt::try_from(&swap.sqrt_price_x96).expect("cannot convert sqrt_price to bigint"),
+        )),
+        _ => None,
+    }
+}

--- a/substreams/ethereum-uniswap-v4/src/modules/5_map_store_balance_changes.rs
+++ b/substreams/ethereum-uniswap-v4/src/modules/5_map_store_balance_changes.rs
@@ -11,15 +11,15 @@ use crate::{
     },
 };
 use substreams::{
-    prelude::{StoreGet, StoreGetInt64},
+    prelude::StoreGet,
     scalar::BigInt,
-    store::{StoreAddBigInt, StoreNew},
+    store::{StoreAddBigInt, StoreGetBigInt, StoreNew},
 };
 
 #[substreams::handlers::map]
 pub fn map_balance_changes(
     events: Events,
-    pools_current_tick_store: StoreGetInt64,
+    pools_current_sqrt_price_store: StoreGetBigInt,
 ) -> Result<BlockBalanceDeltas, anyhow::Error> {
     let balance_deltas = events
         .pool_events
@@ -27,19 +27,14 @@ pub fn map_balance_changes(
         .filter(PoolEvent::can_introduce_balance_changes)
         .map(|e| {
             (
-                pools_current_tick_store
+                pools_current_sqrt_price_store
                     .get_at(e.log_ordinal, format!("pool:{0}", &e.pool_id))
-                    .unwrap_or(0),
+                    .unwrap_or(BigInt::zero()),
                 e,
             )
         })
-        .filter_map(|(current_tick, event)| {
-            event_to_balance_deltas(
-                // Should never fail because we are converting back a value that was originally i32
-                TryInto::<i32>::try_into(current_tick)
-                    .expect("Failed to convert current tick to i32"),
-                event,
-            )
+        .filter_map(|(current_sqrt_price, event)| {
+            event_to_balance_deltas(current_sqrt_price, event)
         })
         .flatten()
         .collect();
@@ -52,12 +47,15 @@ pub fn store_pools_balances(balances_deltas: BlockBalanceDeltas, store: StoreAdd
     tycho_substreams::balances::store_balance_changes(balances_deltas, store);
 }
 
-fn event_to_balance_deltas(current_tick: i32, event: PoolEvent) -> Option<Vec<BalanceDelta>> {
+fn event_to_balance_deltas(
+    current_sqrt_price: BigInt,
+    event: PoolEvent,
+) -> Option<Vec<BalanceDelta>> {
     let address = event.pool_id.as_bytes().to_vec();
     match event.r#type.unwrap() {
         pool_event::Type::ModifyLiquidity(e) => {
             let (delta0, delta1) =
-                get_amount_delta(current_tick, e.tick_lower, e.tick_upper, e.liquidity_delta);
+                get_amount_delta(current_sqrt_price, e.tick_lower, e.tick_upper, e.liquidity_delta);
             Some(vec![
                 BalanceDelta {
                     token: hex::decode(
@@ -145,7 +143,7 @@ impl PoolEvent {
 }
 
 fn get_amount_delta(
-    current_tick: i32,
+    current_sqrt_price: BigInt,
     tick_lower: i32,
     tick_upper: i32,
     liquidity_delta: String,
@@ -157,7 +155,7 @@ fn get_amount_delta(
         .expect("Failed to parse liquidity delta");
 
     let (amount0, amount1) =
-        calculate_token_amounts(current_tick, tick_lower, tick_upper, liquidity_delta)
+        calculate_token_amounts(current_sqrt_price.into(), tick_lower, tick_upper, liquidity_delta)
             .expect("Failed to calculate token amounts from liquidity delta");
     (BigInt::from(amount0), BigInt::from(amount1))
 }

--- a/substreams/ethereum-uniswap-v4/src/modules/5_map_store_balance_changes.rs
+++ b/substreams/ethereum-uniswap-v4/src/modules/5_map_store_balance_changes.rs
@@ -90,12 +90,20 @@ fn event_to_balance_deltas(
         }
 
         pool_event::Type::Swap(e) => {
-            let delta0 = BigInt::from_str(&e.amount0)
+            let mut delta0 = BigInt::from_str(&e.amount0)
                 .unwrap()
                 .neg();
-            let delta1 = BigInt::from_str(&e.amount1)
+            let mut delta1 = BigInt::from_str(&e.amount1)
                 .unwrap()
                 .neg();
+
+            // Remove fees
+            if delta0 > BigInt::zero() {
+                delta0 = delta0.clone() - ((delta0 * e.fee + BigInt::from(500_000)) / 1000000); // adding BigInt::from(500_000) for rounding instead of truncating
+            }
+            if delta1 > BigInt::zero() {
+                delta1 = delta1.clone() - ((delta1 * e.fee + BigInt::from(500_000)) / 1000000); // adding BigInt::from(500_000) for rounding instead of truncating
+            }
 
             Some(vec![
                 BalanceDelta {

--- a/substreams/ethereum-uniswap-v4/src/modules/mod.rs
+++ b/substreams/ethereum-uniswap-v4/src/modules/mod.rs
@@ -14,6 +14,9 @@ mod map_events;
 #[path = "4_store_current_tick.rs"]
 mod store_current_tick;
 
+#[path = "4_store_current_sqrtprice.rs"]
+mod store_current_sqrtprice;
+
 #[path = "5_map_store_balance_changes.rs"]
 mod map_store_balance_changes;
 

--- a/substreams/ethereum-uniswap-v4/src/modules/uni_math.rs
+++ b/substreams/ethereum-uniswap-v4/src/modules/uni_math.rs
@@ -314,6 +314,7 @@ fn get_amount_1_delta(
 mod tests {
     use super::*;
     use num_bigint::BigInt;
+    use rstest::rstest;
     use std::str::FromStr;
     const MIN_TICK: i32 = -887272;
 
@@ -433,29 +434,36 @@ mod tests {
         assert_eq!(amount_0_up, amount_0_down + 1);
     }
 
-    #[test]
-    fn test_calculate_token_amounts_works() {
-        let current_sqrtprice = BigInt::from(79228162514264337593543950336_i128); //SQRT_PRICE at tick 0 boundary
-        let tick_lower = -887270;
-        let tick_upper = 887270;
-        let liquidity_delta = 2779504125;
+    #[rstest]
+    #[case(
+        BigInt::from(79228162514264337593543950336_i128),
+        -887270,
+        887270,
+        2779504125,
+        BigInt::from(2779504125_u128),
+        BigInt::from(2779504125_u128)
+    )]
+    #[case(
+        BigInt::from(17189630842187678489986852982138_i128),
+        -138200,
+        107600,
+        -79381057257465377800177,
+        BigInt::from(-445577797388351_i128),
+        BigInt::from(-17222724212376326765220041_i128)
+    )]
+    fn test_calculate_token_amounts(
+        #[case] current_sqrtprice: BigInt,
+        #[case] tick_lower: i32,
+        #[case] tick_upper: i32,
+        #[case] liquidity_delta: i128,
+        #[case] expected_amount0: BigInt,
+        #[case] expected_amount1: BigInt,
+    ) {
         let (amount0, amount1) =
             calculate_token_amounts(current_sqrtprice, tick_lower, tick_upper, liquidity_delta)
                 .unwrap();
-        assert_eq!(amount0, BigInt::from(2779504125_u128));
-        assert_eq!(amount1, BigInt::from(2779504125_u128));
-    }
 
-    #[test]
-    fn test_calculate_token_amounts_2() {
-        let current_sqrtprice = BigInt::from(17189630842187678489986852982138_i128);
-        let tick_lower = -138200;
-        let tick_upper = 107600;
-        let liquidity_delta = -79381057257465377800177;
-        let (amount0, amount1) =
-            calculate_token_amounts(current_sqrtprice, tick_lower, tick_upper, liquidity_delta)
-                .unwrap();
-        assert_eq!(amount0, BigInt::from(-445577797388351_i128));
-        assert_eq!(amount1, BigInt::from(-17222724212376326765220041_i128));
+        assert_eq!(amount0, expected_amount0);
+        assert_eq!(amount1, expected_amount1);
     }
 }

--- a/substreams/ethereum-uniswap-v4/src/pb/mod.rs
+++ b/substreams/ethereum-uniswap-v4/src/pb/mod.rs
@@ -1,13 +1,4 @@
 // @generated
-pub mod tycho {
-    pub mod evm {
-        // @@protoc_insertion_point(attribute:tycho.evm.v1)
-        pub mod v1 {
-            include!("tycho.evm.v1.rs");
-            // @@protoc_insertion_point(tycho.evm.v1)
-        }
-    }
-}
 pub mod uniswap {
     // @@protoc_insertion_point(attribute:uniswap.v4)
     pub mod v4 {


### PR DESCRIPTION
This PR fixes bugs in our UniswapV4 module that were affecting token balances.

- We were not converting swap deltas correctly  
- We were not calculating token amounts correctly during position modifications  
- We were not subtracting fees from swap deltas