### PR TITLE
Add Peapods Swap Adapter Substreams Package

### DIFF
--- a/substreams/ethereum-peapods/Cargo.toml
+++ b/substreams/ethereum-peapods/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "ethereum-peapods"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+name = "ethereum_peapods"
+crate-type = ["cdylib"]
+
+[dependencies]
+substreams = "0.5.22"
+substreams-ethereum = "0.9.9"
+prost = "0.11"
+tycho-substreams = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", rev = "3c08359" }
+anyhow = "1.0.95"
+ethabi = "18.0.0"
+num-bigint = "0.4.6"
+hex = { version = "0.4", features = ["serde"] }
+itertools = "0.10.5"
+serde = "1.0.217"
+serde-sibor = "0.1.0"
+serde_qs = "0.13.0"
+substreams-helper = { version = "0.0.2", path = "../crates/substreams-helper" }
+
+
+[build-dependencies]
+anyhow = "1"
+substreams-ethereum = "0.9.9"

--- a/substreams/ethereum-peapods/README.md
+++ b/substreams/ethereum-peapods/README.md
@@ -1,0 +1,60 @@
+# Ethereum Peapods Substreams Package
+
+This substreams package indexes token pair creation and price changes within peapod adapters on EVM networks.
+
+## Modules Overview
+
+The package consists of five core modules that work together to track and index protocol changes:
+
+1. `map_function_calls` - Maps adapter contract function calls (Swap, SwapToPrice, Price) into structured FunctionCalls
+2. `store_exchange_price` - Stores exchange prices from function calls in the store
+3. `map_token_pairs` - Creates protocol components for token pairs based on function calls
+4. `store_token_pairs` - Persists token pair protocol components in the store
+5. `map_protocol_changes` - Aggregates changes from function calls and components into BlockChanges
+
+## Usage
+
+First, set your Substreams API token:
+
+```bash
+export SUBSTREAMS_API_TOKEN="your-jwt-token"
+```
+
+Run the substreams GUI:
+
+```bash
+substreams gui substreams.yaml map_protocol_changes \
+  -e base-mainnet.streamingfast.io:443 \
+  --start-block $start_block_num \ 
+  --stop-block $offset \ # Like +50
+  --network base
+```
+
+## Module Details
+
+### map_function_calls
+Identifies and decodes three types of function calls to the adapter contract:
+- `Swap2` - Direct token swaps 
+- `SwapToPrice` - Swaps targeting a specific price
+- `Price` - Price queries for token pairs
+
+### store_exchange_price
+Stores exchange prices from successful swaps and price queries, computing the actual exchange price based on the trade results.
+
+### map_token_pairs
+Creates protocol components for each unique token pair encountered in function calls. Components include:
+- Unique ID based on token addresses
+- Token addresses
+- Adapter contract address
+- Protocol type metadata
+
+### store_token_pairs
+Persists protocol components in the store for later reference.
+
+### map_protocol_changes
+Aggregates protocol changes by:
+- Tracking newly created components per transaction
+- Recording price updates from exchange deltas
+- Organizing changes by transaction
+
+The final output is a BlockChanges structure containing all protocol activity within each block.

--- a/substreams/ethereum-peapods/abi/swap_adapter.json
+++ b/substreams/ethereum-peapods/abi/swap_adapter.json
@@ -1,0 +1,1122 @@
+[
+    {
+        "type": "function",
+        "name": "UPGRADE_INTERFACE_VERSION",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "",
+                "type": "string",
+                "internalType": "string"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "acceptOwnership",
+        "inputs": [],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "calculateFPairedAssetGivenPairedAsset",
+        "inputs": [
+            {
+                "name": "pair",
+                "type": "address",
+                "internalType": "contract IFraxlendPair"
+            },
+            {
+                "name": "amount",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "calculatePTKNAfterBonding",
+        "inputs": [
+            {
+                "name": "pod",
+                "type": "address",
+                "internalType": "contract IDecentralizedIndex"
+            },
+            {
+                "name": "amount",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "calculatePTKNForDebonding",
+        "inputs": [
+            {
+                "name": "pod",
+                "type": "address",
+                "internalType": "contract IDecentralizedIndex"
+            },
+            {
+                "name": "amount",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "calculatePTKNForPairedAsset",
+        "inputs": [
+            {
+                "name": "pod",
+                "type": "address",
+                "internalType": "contract IDecentralizedIndex"
+            },
+            {
+                "name": "amount",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "calculatePTKNGivenPairedAsset",
+        "inputs": [
+            {
+                "name": "pod",
+                "type": "address",
+                "internalType": "contract IDecentralizedIndex"
+            },
+            {
+                "name": "amount",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "calculatePairedAssetForPTKN",
+        "inputs": [
+            {
+                "name": "pod",
+                "type": "address",
+                "internalType": "contract IDecentralizedIndex"
+            },
+            {
+                "name": "amount",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "calculatePairedAssetGivenFPairedAsset",
+        "inputs": [
+            {
+                "name": "pair",
+                "type": "address",
+                "internalType": "contract IFraxlendPair"
+            },
+            {
+                "name": "amount",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "calculatePairedAssetGivenPTKN",
+        "inputs": [
+            {
+                "name": "pod",
+                "type": "address",
+                "internalType": "contract IDecentralizedIndex"
+            },
+            {
+                "name": "amount",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "calculatePairedAssetGivenTKN",
+        "inputs": [
+            {
+                "name": "pod",
+                "type": "address",
+                "internalType": "contract IDecentralizedIndex"
+            },
+            {
+                "name": "amount",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "calculateTKNAfterDebonding",
+        "inputs": [
+            {
+                "name": "pod",
+                "type": "address",
+                "internalType": "contract IDecentralizedIndex"
+            },
+            {
+                "name": "amount",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "calculateTKNForBonding",
+        "inputs": [
+            {
+                "name": "pod",
+                "type": "address",
+                "internalType": "contract IDecentralizedIndex"
+            },
+            {
+                "name": "amount",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "calculateTKNGivenPairedAsset",
+        "inputs": [
+            {
+                "name": "pod",
+                "type": "address",
+                "internalType": "contract IDecentralizedIndex"
+            },
+            {
+                "name": "amount",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "getCapabilities",
+        "inputs": [
+            {
+                "name": "poolId",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            },
+            {
+                "name": "sellToken",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "buyToken",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "capabilities",
+                "type": "uint8[]",
+                "internalType": "enum IERC7815.Capability[]"
+            }
+        ],
+        "stateMutability": "pure"
+    },
+    {
+        "type": "function",
+        "name": "getLimits",
+        "inputs": [
+            {
+                "name": "poolId",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            },
+            {
+                "name": "sellToken",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "buyToken",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "limits",
+                "type": "uint256[]",
+                "internalType": "uint256[]"
+            }
+        ],
+        "stateMutability": "pure"
+    },
+    {
+        "type": "function",
+        "name": "getTokens",
+        "inputs": [
+            {
+                "name": "poolId",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "tokens",
+                "type": "address[]",
+                "internalType": "address[]"
+            }
+        ],
+        "stateMutability": "pure"
+    },
+    {
+        "type": "function",
+        "name": "indexer",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "",
+                "type": "address",
+                "internalType": "contract IIndexManager"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "initialize",
+        "inputs": [
+            {
+                "name": "_indexer",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "_leverageManager",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "_router",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "_owner",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "leverageManager",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "",
+                "type": "address",
+                "internalType": "contract ILeverageManagerAccessControl"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "owner",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "pendingOwner",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "price",
+        "inputs": [
+            {
+                "name": "",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            },
+            {
+                "name": "sellToken",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "buyToken",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "specifiedAmounts",
+                "type": "uint256[]",
+                "internalType": "uint256[]"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "prices",
+                "type": "tuple[]",
+                "internalType": "struct IERC7815.Fraction[]",
+                "components": [
+                    {
+                        "name": "numerator",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "denominator",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    }
+                ]
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "priceDerivative",
+        "inputs": [
+            {
+                "name": "",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            },
+            {
+                "name": "",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "",
+                "type": "uint8",
+                "internalType": "enum IERC7815.DerivativeOrder"
+            },
+            {
+                "name": "",
+                "type": "uint256[]",
+                "internalType": "uint256[]"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "tuple[]",
+                "internalType": "struct IERC7815.Fraction[]",
+                "components": [
+                    {
+                        "name": "numerator",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "denominator",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    }
+                ]
+            }
+        ],
+        "stateMutability": "pure"
+    },
+    {
+        "type": "function",
+        "name": "proxiableUUID",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "renounceOwnership",
+        "inputs": [],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "rescue",
+        "inputs": [
+            {
+                "name": "token",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "amount",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "router",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "",
+                "type": "address",
+                "internalType": "contract IUniswapV2Router02"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "setIndexer",
+        "inputs": [
+            {
+                "name": "_indexer",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "setLegacyPod",
+        "inputs": [
+            {
+                "name": "pod",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "isLegacy",
+                "type": "bool",
+                "internalType": "bool"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "setLeverageManager",
+        "inputs": [
+            {
+                "name": "_leverageManager",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "setRouter",
+        "inputs": [
+            {
+                "name": "_router",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "swap",
+        "inputs": [
+            {
+                "name": "",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            },
+            {
+                "name": "sellToken",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "buyToken",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "side",
+                "type": "uint8",
+                "internalType": "enum IERC7815.OrderSide"
+            },
+            {
+                "name": "specifiedAmount",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "limitAmount",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "trade",
+                "type": "tuple",
+                "internalType": "struct IERC7815.Trade",
+                "components": [
+                    {
+                        "name": "calculatedAmount",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "gasUsed",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "marginalPriceAfterTrade",
+                        "type": "tuple",
+                        "internalType": "struct IERC7815.Fraction",
+                        "components": [
+                            {
+                                "name": "numerator",
+                                "type": "uint256",
+                                "internalType": "uint256"
+                            },
+                            {
+                                "name": "denominator",
+                                "type": "uint256",
+                                "internalType": "uint256"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "swap",
+        "inputs": [
+            {
+                "name": "",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            },
+            {
+                "name": "sellToken",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "buyToken",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "side",
+                "type": "uint8",
+                "internalType": "enum IERC7815.OrderSide"
+            },
+            {
+                "name": "specifiedAmount",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "trade",
+                "type": "tuple",
+                "internalType": "struct IERC7815.Trade",
+                "components": [
+                    {
+                        "name": "calculatedAmount",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "gasUsed",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "marginalPriceAfterTrade",
+                        "type": "tuple",
+                        "internalType": "struct IERC7815.Fraction",
+                        "components": [
+                            {
+                                "name": "numerator",
+                                "type": "uint256",
+                                "internalType": "uint256"
+                            },
+                            {
+                                "name": "denominator",
+                                "type": "uint256",
+                                "internalType": "uint256"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "swapToPrice",
+        "inputs": [
+            {
+                "name": "poolId",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            },
+            {
+                "name": "sellToken",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "buyToken",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "limitPrice",
+                "type": "tuple",
+                "internalType": "struct IERC7815.Fraction",
+                "components": [
+                    {
+                        "name": "numerator",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "denominator",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    }
+                ]
+            }
+        ],
+        "outputs": [
+            {
+                "name": "trade",
+                "type": "tuple",
+                "internalType": "struct IERC7815.Trade",
+                "components": [
+                    {
+                        "name": "calculatedAmount",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "gasUsed",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "marginalPriceAfterTrade",
+                        "type": "tuple",
+                        "internalType": "struct IERC7815.Fraction",
+                        "components": [
+                            {
+                                "name": "numerator",
+                                "type": "uint256",
+                                "internalType": "uint256"
+                            },
+                            {
+                                "name": "denominator",
+                                "type": "uint256",
+                                "internalType": "uint256"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "transferOwnership",
+        "inputs": [
+            {
+                "name": "newOwner",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "upgradeToAndCall",
+        "inputs": [
+            {
+                "name": "newImplementation",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "data",
+                "type": "bytes",
+                "internalType": "bytes"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "payable"
+    },
+    {
+        "type": "event",
+        "name": "Initialized",
+        "inputs": [
+            {
+                "name": "version",
+                "type": "uint64",
+                "indexed": false,
+                "internalType": "uint64"
+            }
+        ],
+        "anonymous": false
+    },
+    {
+        "type": "event",
+        "name": "OwnershipTransferStarted",
+        "inputs": [
+            {
+                "name": "previousOwner",
+                "type": "address",
+                "indexed": true,
+                "internalType": "address"
+            },
+            {
+                "name": "newOwner",
+                "type": "address",
+                "indexed": true,
+                "internalType": "address"
+            }
+        ],
+        "anonymous": false
+    },
+    {
+        "type": "event",
+        "name": "OwnershipTransferred",
+        "inputs": [
+            {
+                "name": "previousOwner",
+                "type": "address",
+                "indexed": true,
+                "internalType": "address"
+            },
+            {
+                "name": "newOwner",
+                "type": "address",
+                "indexed": true,
+                "internalType": "address"
+            }
+        ],
+        "anonymous": false
+    },
+    {
+        "type": "event",
+        "name": "Upgraded",
+        "inputs": [
+            {
+                "name": "implementation",
+                "type": "address",
+                "indexed": true,
+                "internalType": "address"
+            }
+        ],
+        "anonymous": false
+    },
+    {
+        "type": "error",
+        "name": "AddressEmptyCode",
+        "inputs": [
+            {
+                "name": "target",
+                "type": "address",
+                "internalType": "address"
+            }
+        ]
+    },
+    {
+        "type": "error",
+        "name": "ERC1967InvalidImplementation",
+        "inputs": [
+            {
+                "name": "implementation",
+                "type": "address",
+                "internalType": "address"
+            }
+        ]
+    },
+    {
+        "type": "error",
+        "name": "ERC1967NonPayable",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "FailedCall",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "InvalidInitialization",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "LimitExceeded",
+        "inputs": [
+            {
+                "name": "limit",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ]
+    },
+    {
+        "type": "error",
+        "name": "NotImplemented",
+        "inputs": [
+            {
+                "name": "reason",
+                "type": "string",
+                "internalType": "string"
+            }
+        ]
+    },
+    {
+        "type": "error",
+        "name": "NotInitializing",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "OwnableInvalidOwner",
+        "inputs": [
+            {
+                "name": "owner",
+                "type": "address",
+                "internalType": "address"
+            }
+        ]
+    },
+    {
+        "type": "error",
+        "name": "OwnableUnauthorizedAccount",
+        "inputs": [
+            {
+                "name": "account",
+                "type": "address",
+                "internalType": "address"
+            }
+        ]
+    },
+    {
+        "type": "error",
+        "name": "SafeERC20FailedOperation",
+        "inputs": [
+            {
+                "name": "token",
+                "type": "address",
+                "internalType": "address"
+            }
+        ]
+    },
+    {
+        "type": "error",
+        "name": "SwapAdapter__InvalidBuyToken",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "SwapAdapter__InvalidSellToken",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "SwapAdapter__SlippageLimit",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "UUPSUnauthorizedCallContext",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "UUPSUnsupportedProxiableUUID",
+        "inputs": [
+            {
+                "name": "slot",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            }
+        ]
+    },
+    {
+        "type": "error",
+        "name": "Unavailable",
+        "inputs": [
+            {
+                "name": "reason",
+                "type": "string",
+                "internalType": "string"
+            }
+        ]
+    }
+]

--- a/substreams/ethereum-peapods/buf.gen.yaml
+++ b/substreams/ethereum-peapods/buf.gen.yaml
@@ -1,0 +1,12 @@
+
+version: v1
+plugins:
+- plugin: buf.build/community/neoeinstein-prost:v0.2.2
+  out: src/pb
+  opt:
+    - file_descriptor_set=false
+
+- plugin: buf.build/community/neoeinstein-prost-crate:v0.3.1
+  out: src/pb
+  opt:
+    - no_features

--- a/substreams/ethereum-peapods/build.rs
+++ b/substreams/ethereum-peapods/build.rs
@@ -1,0 +1,49 @@
+use anyhow::Result;
+use std::{fs, io::Write};
+use substreams_ethereum::Abigen;
+
+fn main() -> Result<()> {
+    let abi_folder = "abi";
+    let output_folder = "src/abi";
+
+    let abis = fs::read_dir(abi_folder)?;
+
+    let mut files = abis.collect::<Result<Vec<_>, _>>()?;
+
+    // Sort the files by their name
+    files.sort_by_key(|a| a.file_name());
+
+    let mut mod_rs_content = String::new();
+    mod_rs_content.push_str("#![allow(clippy::all)]\n");
+
+    for file in files {
+        let file_name = file.file_name();
+        let file_name = file_name.to_string_lossy();
+
+        if !file_name.ends_with(".json") {
+            continue;
+        }
+
+        let contract_name = file_name.split('.').next().unwrap();
+
+        let input_path = format!("{}/{}", abi_folder, file_name);
+        let output_path = format!("{}/{}.rs", output_folder, contract_name);
+
+        mod_rs_content.push_str(&format!("pub mod {};\n", contract_name));
+
+        if std::path::Path::new(&output_path).exists() {
+            continue;
+        }
+
+        Abigen::new(contract_name, &input_path)?
+            .generate()?
+            .write_to_file(&output_path)?;
+    }
+
+    let mod_rs_path = format!("{}/mod.rs", output_folder);
+    let mut mod_rs_file = fs::File::create(mod_rs_path)?;
+
+    mod_rs_file.write_all(mod_rs_content.as_bytes())?;
+
+    Ok(())
+}

--- a/substreams/ethereum-peapods/integration_test.tycho.yaml
+++ b/substreams/ethereum-peapods/integration_test.tycho.yaml
@@ -1,0 +1,57 @@
+# Name of the substreams config file in your substreams module. Usually "./substreams.yaml"
+substreams_yaml_path: ./substreams.yaml
+# Name of the adapter contract, usually: ProtocolSwapAdapter"
+adapter_contract: "SwapAdapter"
+# Constructor signature of the Adapter contract"
+adapter_build_signature: "constructor(address)"
+# A comma separated list of args to be passed to the contructor of the Adapter contract"
+adapter_build_args: "0x0000000000000000000000000000000000000000"
+# Whether or not the testing script should skip checking balances of the protocol components.
+# If set to `true` please always add a reason why it's skipped.
+skip_balance_check: false
+# A list of accounts that need to be indexed to run the tests properly.
+# Usually used when there is a global component required by all pools and created before the tested range of blocks. For example a factory or a vault.
+# Please note that this component needs to be indexed by your substreams module, this feature is only for testing purpose.
+# Also please always add a reason why this account is needed for your tests.
+# This will be applied to each test.
+initialized_accounts:
+  - "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84" # Needed for ....
+# A list of protocol types names created by your Substreams module.
+protocol_type_names:
+  - "type_name_1"
+  - "type_name_2"
+# A list of tests.
+tests:
+  # Name of the test
+  - name: test_pool_creation
+    # Indexed block range
+    start_block: 123
+    stop_block: 456
+    # Same as global `initialized_accounts` but only scoped to this test.
+    initialized_accounts:
+      - "0x0c0e5f2fF0ff18a3be9b835635039256dC4B4963" # Needed for ....
+    # A list of expected component indexed in the block range. Each component must match perfectly the `ProtocolComponent` indexed by your subtreams module.
+    expected_components:
+      - id: "0xbebc44782c7db0a1a60cb6fe97d0b483032ff1c7"
+        tokens:
+          - "0xdac17f958d2ee523a2206206994597c13d831ec7"
+          - "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+          - "0x6b175474e89094c44da98b954eedeac495271d0f"
+        static_attributes:
+          attr_1: "value"
+          attr_2: "value"
+        creation_tx: "0x20793bbf260912aae189d5d261ff003c9b9166da8191d8f9d63ff1c7722f3ac6"
+        # Whether or not the script should skip trying to simulate a swap on this component.
+        # If set to `true` please always add a reason why it's skipped.
+        skip_simulation: false
+  - name: test_something_else
+    start_block: 123
+    stop_block: 456
+    expected_components:
+      - id: "0xdc24316b9ae028f1497c275eb9192a3ea0f67022"
+        tokens:
+          - "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"
+          - "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84"
+        static_attributes: null
+        creation_tx: "0xfac67ecbd423a5b915deff06045ec9343568edaec34ae95c43d35f2c018afdaa"
+        skip_simulation: true # If true, always add a reason

--- a/substreams/ethereum-peapods/proto/v1/adapter.proto
+++ b/substreams/ethereum-peapods/proto/v1/adapter.proto
@@ -1,0 +1,58 @@
+syntax = "proto3";
+
+package adapter.v1;
+
+message Trade {
+    string calculated_amount = 1;
+    string gas_used = 2;
+    string marginal_price_after_trade = 3;
+}
+
+enum OrderSide {
+    SELL = 0;
+    BUY = 1;
+}
+
+// A struct describing a transaction.
+message Transaction {
+    // The transaction hash.
+    bytes hash = 1;
+    // The sender of the transaction.
+    bytes from = 2;
+    // The receiver of the transaction.
+    bytes to = 3;
+    // The transactions index within the block.
+    uint32 index = 4;
+}
+
+message FunctionCall {
+    string id = 1;
+    string sell_token = 2;
+    string buy_token = 3;
+    Transaction transaction = 4;
+    oneof call_type {
+        SwapCallData swap = 5;
+        PriceCallData price = 6;
+        SwapToPriceCallData swap_to_price = 7;
+    }
+}
+
+message SwapCallData {
+    OrderSide side = 1;
+    uint64 specified_amount = 2;
+    Trade result = 3;
+}
+
+message PriceCallData {
+    repeated bytes specified_amounts = 1;
+    repeated string prices = 2;
+}
+
+message SwapToPriceCallData {
+    string limit_price = 1;
+    Trade result = 2;
+}
+
+message FunctionCalls {
+    repeated FunctionCall calls = 1;
+}

--- a/substreams/ethereum-peapods/src/abi/mod.rs
+++ b/substreams/ethereum-peapods/src/abi/mod.rs
@@ -1,0 +1,2 @@
+#![allow(clippy::all)]
+pub mod swap_adapter;

--- a/substreams/ethereum-peapods/src/abi/swap_adapter.rs
+++ b/substreams/ethereum-peapods/src/abi/swap_adapter.rs
@@ -1,0 +1,4538 @@
+const INTERNAL_ERR: &'static str = "`ethabi_derive` internal error";
+/// Contract's functions.
+#[allow(dead_code, unused_imports, unused_variables)]
+pub mod functions {
+    use super::INTERNAL_ERR;
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct AcceptOwnership {}
+    impl AcceptOwnership {
+        const METHOD_ID: [u8; 4] = [121u8, 186u8, 80u8, 151u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Ok(Self {})
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+    }
+    impl substreams_ethereum::Function for AcceptOwnership {
+        const NAME: &'static str = "acceptOwnership";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct CalculateFPairedAssetGivenPairedAsset {
+        pub pair: Vec<u8>,
+        pub amount: substreams::scalar::BigInt,
+    }
+    impl CalculateFPairedAssetGivenPairedAsset {
+        const METHOD_ID: [u8; 4] = [149u8, 43u8, 178u8, 20u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Address, ethabi::ParamType::Uint(256usize)],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                pair: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                amount: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.pair)),
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self.amount.clone().to_bytes_be() {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Uint(256usize)], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok({
+                let mut v = [0 as u8; 32];
+                values
+                    .pop()
+                    .expect("one output data should have existed")
+                    .into_uint()
+                    .expect(INTERNAL_ERR)
+                    .to_big_endian(v.as_mut_slice());
+                substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+            })
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<substreams::scalar::BigInt> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for CalculateFPairedAssetGivenPairedAsset {
+        const NAME: &'static str = "calculateFPairedAssetGivenPairedAsset";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<substreams::scalar::BigInt>
+        for CalculateFPairedAssetGivenPairedAsset
+    {
+        fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct CalculatePairedAssetForPtkn {
+        pub pod: Vec<u8>,
+        pub amount: substreams::scalar::BigInt,
+    }
+    impl CalculatePairedAssetForPtkn {
+        const METHOD_ID: [u8; 4] = [29u8, 116u8, 122u8, 212u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Address, ethabi::ParamType::Uint(256usize)],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                pod: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                amount: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.pod)),
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self.amount.clone().to_bytes_be() {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Uint(256usize)], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok({
+                let mut v = [0 as u8; 32];
+                values
+                    .pop()
+                    .expect("one output data should have existed")
+                    .into_uint()
+                    .expect(INTERNAL_ERR)
+                    .to_big_endian(v.as_mut_slice());
+                substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+            })
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<substreams::scalar::BigInt> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for CalculatePairedAssetForPtkn {
+        const NAME: &'static str = "calculatePairedAssetForPTKN";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<substreams::scalar::BigInt>
+        for CalculatePairedAssetForPtkn
+    {
+        fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct CalculatePairedAssetGivenFPairedAsset {
+        pub pair: Vec<u8>,
+        pub amount: substreams::scalar::BigInt,
+    }
+    impl CalculatePairedAssetGivenFPairedAsset {
+        const METHOD_ID: [u8; 4] = [190u8, 6u8, 40u8, 244u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Address, ethabi::ParamType::Uint(256usize)],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                pair: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                amount: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.pair)),
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self.amount.clone().to_bytes_be() {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Uint(256usize)], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok({
+                let mut v = [0 as u8; 32];
+                values
+                    .pop()
+                    .expect("one output data should have existed")
+                    .into_uint()
+                    .expect(INTERNAL_ERR)
+                    .to_big_endian(v.as_mut_slice());
+                substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+            })
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<substreams::scalar::BigInt> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for CalculatePairedAssetGivenFPairedAsset {
+        const NAME: &'static str = "calculatePairedAssetGivenFPairedAsset";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<substreams::scalar::BigInt>
+        for CalculatePairedAssetGivenFPairedAsset
+    {
+        fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct CalculatePairedAssetGivenPtkn {
+        pub pod: Vec<u8>,
+        pub amount: substreams::scalar::BigInt,
+    }
+    impl CalculatePairedAssetGivenPtkn {
+        const METHOD_ID: [u8; 4] = [68u8, 146u8, 91u8, 46u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Address, ethabi::ParamType::Uint(256usize)],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                pod: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                amount: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.pod)),
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self.amount.clone().to_bytes_be() {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Uint(256usize)], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok({
+                let mut v = [0 as u8; 32];
+                values
+                    .pop()
+                    .expect("one output data should have existed")
+                    .into_uint()
+                    .expect(INTERNAL_ERR)
+                    .to_big_endian(v.as_mut_slice());
+                substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+            })
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<substreams::scalar::BigInt> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for CalculatePairedAssetGivenPtkn {
+        const NAME: &'static str = "calculatePairedAssetGivenPTKN";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<substreams::scalar::BigInt>
+        for CalculatePairedAssetGivenPtkn
+    {
+        fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct CalculatePairedAssetGivenTkn {
+        pub pod: Vec<u8>,
+        pub amount: substreams::scalar::BigInt,
+    }
+    impl CalculatePairedAssetGivenTkn {
+        const METHOD_ID: [u8; 4] = [217u8, 39u8, 213u8, 253u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Address, ethabi::ParamType::Uint(256usize)],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                pod: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                amount: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.pod)),
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self.amount.clone().to_bytes_be() {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Uint(256usize)], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok({
+                let mut v = [0 as u8; 32];
+                values
+                    .pop()
+                    .expect("one output data should have existed")
+                    .into_uint()
+                    .expect(INTERNAL_ERR)
+                    .to_big_endian(v.as_mut_slice());
+                substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+            })
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<substreams::scalar::BigInt> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for CalculatePairedAssetGivenTkn {
+        const NAME: &'static str = "calculatePairedAssetGivenTKN";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<substreams::scalar::BigInt>
+        for CalculatePairedAssetGivenTkn
+    {
+        fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct CalculatePtknAfterBonding {
+        pub pod: Vec<u8>,
+        pub amount: substreams::scalar::BigInt,
+    }
+    impl CalculatePtknAfterBonding {
+        const METHOD_ID: [u8; 4] = [5u8, 232u8, 131u8, 157u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Address, ethabi::ParamType::Uint(256usize)],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                pod: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                amount: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.pod)),
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self.amount.clone().to_bytes_be() {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Uint(256usize)], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok({
+                let mut v = [0 as u8; 32];
+                values
+                    .pop()
+                    .expect("one output data should have existed")
+                    .into_uint()
+                    .expect(INTERNAL_ERR)
+                    .to_big_endian(v.as_mut_slice());
+                substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+            })
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<substreams::scalar::BigInt> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for CalculatePtknAfterBonding {
+        const NAME: &'static str = "calculatePTKNAfterBonding";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<substreams::scalar::BigInt>
+        for CalculatePtknAfterBonding
+    {
+        fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct CalculatePtknForDebonding {
+        pub pod: Vec<u8>,
+        pub amount: substreams::scalar::BigInt,
+    }
+    impl CalculatePtknForDebonding {
+        const METHOD_ID: [u8; 4] = [165u8, 208u8, 101u8, 204u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Address, ethabi::ParamType::Uint(256usize)],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                pod: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                amount: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.pod)),
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self.amount.clone().to_bytes_be() {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Uint(256usize)], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok({
+                let mut v = [0 as u8; 32];
+                values
+                    .pop()
+                    .expect("one output data should have existed")
+                    .into_uint()
+                    .expect(INTERNAL_ERR)
+                    .to_big_endian(v.as_mut_slice());
+                substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+            })
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<substreams::scalar::BigInt> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for CalculatePtknForDebonding {
+        const NAME: &'static str = "calculatePTKNForDebonding";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<substreams::scalar::BigInt>
+        for CalculatePtknForDebonding
+    {
+        fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct CalculatePtknForPairedAsset {
+        pub pod: Vec<u8>,
+        pub amount: substreams::scalar::BigInt,
+    }
+    impl CalculatePtknForPairedAsset {
+        const METHOD_ID: [u8; 4] = [206u8, 69u8, 218u8, 158u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Address, ethabi::ParamType::Uint(256usize)],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                pod: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                amount: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.pod)),
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self.amount.clone().to_bytes_be() {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Uint(256usize)], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok({
+                let mut v = [0 as u8; 32];
+                values
+                    .pop()
+                    .expect("one output data should have existed")
+                    .into_uint()
+                    .expect(INTERNAL_ERR)
+                    .to_big_endian(v.as_mut_slice());
+                substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+            })
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<substreams::scalar::BigInt> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for CalculatePtknForPairedAsset {
+        const NAME: &'static str = "calculatePTKNForPairedAsset";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<substreams::scalar::BigInt>
+        for CalculatePtknForPairedAsset
+    {
+        fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct CalculatePtknGivenPairedAsset {
+        pub pod: Vec<u8>,
+        pub amount: substreams::scalar::BigInt,
+    }
+    impl CalculatePtknGivenPairedAsset {
+        const METHOD_ID: [u8; 4] = [44u8, 76u8, 9u8, 2u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Address, ethabi::ParamType::Uint(256usize)],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                pod: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                amount: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.pod)),
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self.amount.clone().to_bytes_be() {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Uint(256usize)], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok({
+                let mut v = [0 as u8; 32];
+                values
+                    .pop()
+                    .expect("one output data should have existed")
+                    .into_uint()
+                    .expect(INTERNAL_ERR)
+                    .to_big_endian(v.as_mut_slice());
+                substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+            })
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<substreams::scalar::BigInt> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for CalculatePtknGivenPairedAsset {
+        const NAME: &'static str = "calculatePTKNGivenPairedAsset";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<substreams::scalar::BigInt>
+        for CalculatePtknGivenPairedAsset
+    {
+        fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct CalculateTknAfterDebonding {
+        pub pod: Vec<u8>,
+        pub amount: substreams::scalar::BigInt,
+    }
+    impl CalculateTknAfterDebonding {
+        const METHOD_ID: [u8; 4] = [147u8, 135u8, 187u8, 192u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Address, ethabi::ParamType::Uint(256usize)],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                pod: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                amount: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.pod)),
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self.amount.clone().to_bytes_be() {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Uint(256usize)], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok({
+                let mut v = [0 as u8; 32];
+                values
+                    .pop()
+                    .expect("one output data should have existed")
+                    .into_uint()
+                    .expect(INTERNAL_ERR)
+                    .to_big_endian(v.as_mut_slice());
+                substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+            })
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<substreams::scalar::BigInt> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for CalculateTknAfterDebonding {
+        const NAME: &'static str = "calculateTKNAfterDebonding";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<substreams::scalar::BigInt>
+        for CalculateTknAfterDebonding
+    {
+        fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct CalculateTknForBonding {
+        pub pod: Vec<u8>,
+        pub amount: substreams::scalar::BigInt,
+    }
+    impl CalculateTknForBonding {
+        const METHOD_ID: [u8; 4] = [234u8, 165u8, 73u8, 185u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Address, ethabi::ParamType::Uint(256usize)],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                pod: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                amount: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.pod)),
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self.amount.clone().to_bytes_be() {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Uint(256usize)], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok({
+                let mut v = [0 as u8; 32];
+                values
+                    .pop()
+                    .expect("one output data should have existed")
+                    .into_uint()
+                    .expect(INTERNAL_ERR)
+                    .to_big_endian(v.as_mut_slice());
+                substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+            })
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<substreams::scalar::BigInt> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for CalculateTknForBonding {
+        const NAME: &'static str = "calculateTKNForBonding";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<substreams::scalar::BigInt> for CalculateTknForBonding {
+        fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct CalculateTknGivenPairedAsset {
+        pub pod: Vec<u8>,
+        pub amount: substreams::scalar::BigInt,
+    }
+    impl CalculateTknGivenPairedAsset {
+        const METHOD_ID: [u8; 4] = [47u8, 52u8, 52u8, 154u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Address, ethabi::ParamType::Uint(256usize)],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                pod: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                amount: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.pod)),
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self.amount.clone().to_bytes_be() {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Uint(256usize)], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok({
+                let mut v = [0 as u8; 32];
+                values
+                    .pop()
+                    .expect("one output data should have existed")
+                    .into_uint()
+                    .expect(INTERNAL_ERR)
+                    .to_big_endian(v.as_mut_slice());
+                substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+            })
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<substreams::scalar::BigInt> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for CalculateTknGivenPairedAsset {
+        const NAME: &'static str = "calculateTKNGivenPairedAsset";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<substreams::scalar::BigInt>
+        for CalculateTknGivenPairedAsset
+    {
+        fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct GetCapabilities {
+        pub pool_id: [u8; 32usize],
+        pub sell_token: Vec<u8>,
+        pub buy_token: Vec<u8>,
+    }
+    impl GetCapabilities {
+        const METHOD_ID: [u8; 4] = [72u8, 189u8, 125u8, 253u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[
+                    ethabi::ParamType::FixedBytes(32usize),
+                    ethabi::ParamType::Address,
+                    ethabi::ParamType::Address,
+                ],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                pool_id: {
+                    let mut result = [0u8; 32];
+                    let v = values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_fixed_bytes()
+                        .expect(INTERNAL_ERR);
+                    result.copy_from_slice(&v);
+                    result
+                },
+                sell_token: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                buy_token: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::FixedBytes(self.pool_id.as_ref().to_vec()),
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.sell_token)),
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.buy_token)),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<Vec<substreams::scalar::BigInt>, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<Vec<substreams::scalar::BigInt>, String> {
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Array(Box::new(ethabi::ParamType::Uint(8usize)))],
+                data.as_ref(),
+            )
+            .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok(values
+                .pop()
+                .expect("one output data should have existed")
+                .into_array()
+                .expect(INTERNAL_ERR)
+                .into_iter()
+                .map(|inner| {
+                    let mut v = [0 as u8; 32];
+                    inner
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                })
+                .collect())
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<Vec<substreams::scalar::BigInt>> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for GetCapabilities {
+        const NAME: &'static str = "getCapabilities";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<Vec<substreams::scalar::BigInt>> for GetCapabilities {
+        fn output(data: &[u8]) -> Result<Vec<substreams::scalar::BigInt>, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct GetLimits {
+        pub pool_id: [u8; 32usize],
+        pub sell_token: Vec<u8>,
+        pub buy_token: Vec<u8>,
+    }
+    impl GetLimits {
+        const METHOD_ID: [u8; 4] = [169u8, 39u8, 15u8, 190u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[
+                    ethabi::ParamType::FixedBytes(32usize),
+                    ethabi::ParamType::Address,
+                    ethabi::ParamType::Address,
+                ],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                pool_id: {
+                    let mut result = [0u8; 32];
+                    let v = values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_fixed_bytes()
+                        .expect(INTERNAL_ERR);
+                    result.copy_from_slice(&v);
+                    result
+                },
+                sell_token: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                buy_token: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::FixedBytes(self.pool_id.as_ref().to_vec()),
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.sell_token)),
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.buy_token)),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<Vec<substreams::scalar::BigInt>, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<Vec<substreams::scalar::BigInt>, String> {
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Array(Box::new(ethabi::ParamType::Uint(256usize)))],
+                data.as_ref(),
+            )
+            .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok(values
+                .pop()
+                .expect("one output data should have existed")
+                .into_array()
+                .expect(INTERNAL_ERR)
+                .into_iter()
+                .map(|inner| {
+                    let mut v = [0 as u8; 32];
+                    inner
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                })
+                .collect())
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<Vec<substreams::scalar::BigInt>> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for GetLimits {
+        const NAME: &'static str = "getLimits";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<Vec<substreams::scalar::BigInt>> for GetLimits {
+        fn output(data: &[u8]) -> Result<Vec<substreams::scalar::BigInt>, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct GetTokens {
+        pub pool_id: [u8; 32usize],
+    }
+    impl GetTokens {
+        const METHOD_ID: [u8; 4] = [236u8, 187u8, 192u8, 51u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values =
+                ethabi::decode(&[ethabi::ParamType::FixedBytes(32usize)], maybe_data.unwrap())
+                    .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                pool_id: {
+                    let mut result = [0u8; 32];
+                    let v = values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_fixed_bytes()
+                        .expect(INTERNAL_ERR);
+                    result.copy_from_slice(&v);
+                    result
+                },
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[ethabi::Token::FixedBytes(self.pool_id.as_ref().to_vec())]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<Vec<Vec<u8>>, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<Vec<Vec<u8>>, String> {
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Array(Box::new(ethabi::ParamType::Address))],
+                data.as_ref(),
+            )
+            .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok(values
+                .pop()
+                .expect("one output data should have existed")
+                .into_array()
+                .expect(INTERNAL_ERR)
+                .into_iter()
+                .map(|inner| {
+                    inner
+                        .into_address()
+                        .expect(INTERNAL_ERR)
+                        .as_bytes()
+                        .to_vec()
+                })
+                .collect())
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<Vec<Vec<u8>>> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for GetTokens {
+        const NAME: &'static str = "getTokens";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<Vec<Vec<u8>>> for GetTokens {
+        fn output(data: &[u8]) -> Result<Vec<Vec<u8>>, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Indexer {}
+    impl Indexer {
+        const METHOD_ID: [u8; 4] = [224u8, 97u8, 24u8, 183u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Ok(Self {})
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<Vec<u8>, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<Vec<u8>, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Address], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok(values
+                .pop()
+                .expect("one output data should have existed")
+                .into_address()
+                .expect(INTERNAL_ERR)
+                .as_bytes()
+                .to_vec())
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<Vec<u8>> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Indexer {
+        const NAME: &'static str = "indexer";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<Vec<u8>> for Indexer {
+        fn output(data: &[u8]) -> Result<Vec<u8>, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Initialize {
+        pub indexer: Vec<u8>,
+        pub leverage_manager: Vec<u8>,
+        pub router: Vec<u8>,
+        pub owner: Vec<u8>,
+    }
+    impl Initialize {
+        const METHOD_ID: [u8; 4] = [248u8, 200u8, 118u8, 94u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[
+                    ethabi::ParamType::Address,
+                    ethabi::ParamType::Address,
+                    ethabi::ParamType::Address,
+                    ethabi::ParamType::Address,
+                ],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                indexer: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                leverage_manager: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                router: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                owner: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.indexer)),
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.leverage_manager)),
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.router)),
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.owner)),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Initialize {
+        const NAME: &'static str = "initialize";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct LeverageManager {}
+    impl LeverageManager {
+        const METHOD_ID: [u8; 4] = [129u8, 253u8, 108u8, 2u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Ok(Self {})
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<Vec<u8>, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<Vec<u8>, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Address], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok(values
+                .pop()
+                .expect("one output data should have existed")
+                .into_address()
+                .expect(INTERNAL_ERR)
+                .as_bytes()
+                .to_vec())
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<Vec<u8>> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for LeverageManager {
+        const NAME: &'static str = "leverageManager";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<Vec<u8>> for LeverageManager {
+        fn output(data: &[u8]) -> Result<Vec<u8>, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Owner {}
+    impl Owner {
+        const METHOD_ID: [u8; 4] = [141u8, 165u8, 203u8, 91u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Ok(Self {})
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<Vec<u8>, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<Vec<u8>, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Address], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok(values
+                .pop()
+                .expect("one output data should have existed")
+                .into_address()
+                .expect(INTERNAL_ERR)
+                .as_bytes()
+                .to_vec())
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<Vec<u8>> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Owner {
+        const NAME: &'static str = "owner";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<Vec<u8>> for Owner {
+        fn output(data: &[u8]) -> Result<Vec<u8>, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct PendingOwner {}
+    impl PendingOwner {
+        const METHOD_ID: [u8; 4] = [227u8, 12u8, 57u8, 120u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Ok(Self {})
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<Vec<u8>, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<Vec<u8>, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Address], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok(values
+                .pop()
+                .expect("one output data should have existed")
+                .into_address()
+                .expect(INTERNAL_ERR)
+                .as_bytes()
+                .to_vec())
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<Vec<u8>> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for PendingOwner {
+        const NAME: &'static str = "pendingOwner";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<Vec<u8>> for PendingOwner {
+        fn output(data: &[u8]) -> Result<Vec<u8>, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Price {
+        pub param0: [u8; 32usize],
+        pub sell_token: Vec<u8>,
+        pub buy_token: Vec<u8>,
+        pub specified_amounts: Vec<substreams::scalar::BigInt>,
+    }
+    impl Price {
+        const METHOD_ID: [u8; 4] = [170u8, 214u8, 228u8, 136u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[
+                    ethabi::ParamType::FixedBytes(32usize),
+                    ethabi::ParamType::Address,
+                    ethabi::ParamType::Address,
+                    ethabi::ParamType::Array(Box::new(ethabi::ParamType::Uint(256usize))),
+                ],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                param0: {
+                    let mut result = [0u8; 32];
+                    let v = values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_fixed_bytes()
+                        .expect(INTERNAL_ERR);
+                    result.copy_from_slice(&v);
+                    result
+                },
+                sell_token: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                buy_token: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                specified_amounts: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_array()
+                    .expect(INTERNAL_ERR)
+                    .into_iter()
+                    .map(|inner| {
+                        let mut v = [0 as u8; 32];
+                        inner
+                            .into_uint()
+                            .expect(INTERNAL_ERR)
+                            .to_big_endian(v.as_mut_slice());
+                        substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                    })
+                    .collect(),
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::FixedBytes(self.param0.as_ref().to_vec()),
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.sell_token)),
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.buy_token)),
+                {
+                    let v = self
+                        .specified_amounts
+                        .iter()
+                        .map(|inner| {
+                            ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                                match inner.clone().to_bytes_be() {
+                                    (num_bigint::Sign::Plus, bytes) => bytes,
+                                    (num_bigint::Sign::NoSign, bytes) => bytes,
+                                    (num_bigint::Sign::Minus, _) => {
+                                        panic!("negative numbers are not supported")
+                                    }
+                                }
+                                .as_slice(),
+                            ))
+                        })
+                        .collect();
+                    ethabi::Token::Array(v)
+                },
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<Vec<(substreams::scalar::BigInt, substreams::scalar::BigInt)>, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(
+            data: &[u8],
+        ) -> Result<Vec<(substreams::scalar::BigInt, substreams::scalar::BigInt)>, String> {
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Array(Box::new(ethabi::ParamType::Tuple(vec![
+                    ethabi::ParamType::Uint(256usize),
+                    ethabi::ParamType::Uint(256usize),
+                ])))],
+                data.as_ref(),
+            )
+            .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok(values
+                .pop()
+                .expect("one output data should have existed")
+                .into_array()
+                .expect(INTERNAL_ERR)
+                .into_iter()
+                .map(|inner| {
+                    let tuple_elements = inner.into_tuple().expect(INTERNAL_ERR);
+                    (
+                        {
+                            let mut v = [0 as u8; 32];
+                            tuple_elements[0usize]
+                                .clone()
+                                .into_uint()
+                                .expect(INTERNAL_ERR)
+                                .to_big_endian(v.as_mut_slice());
+                            substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                        },
+                        {
+                            let mut v = [0 as u8; 32];
+                            tuple_elements[1usize]
+                                .clone()
+                                .into_uint()
+                                .expect(INTERNAL_ERR)
+                                .to_big_endian(v.as_mut_slice());
+                            substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                        },
+                    )
+                })
+                .collect())
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(
+            &self,
+            address: Vec<u8>,
+        ) -> Option<Vec<(substreams::scalar::BigInt, substreams::scalar::BigInt)>> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Price {
+        const NAME: &'static str = "price";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl
+        substreams_ethereum::rpc::RPCDecodable<
+            Vec<(substreams::scalar::BigInt, substreams::scalar::BigInt)>,
+        > for Price
+    {
+        fn output(
+            data: &[u8],
+        ) -> Result<Vec<(substreams::scalar::BigInt, substreams::scalar::BigInt)>, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct PriceDerivative {
+        pub param0: [u8; 32usize],
+        pub param1: Vec<u8>,
+        pub param2: Vec<u8>,
+        pub param3: substreams::scalar::BigInt,
+        pub param4: Vec<substreams::scalar::BigInt>,
+    }
+    impl PriceDerivative {
+        const METHOD_ID: [u8; 4] = [107u8, 52u8, 143u8, 113u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[
+                    ethabi::ParamType::FixedBytes(32usize),
+                    ethabi::ParamType::Address,
+                    ethabi::ParamType::Address,
+                    ethabi::ParamType::Uint(8usize),
+                    ethabi::ParamType::Array(Box::new(ethabi::ParamType::Uint(256usize))),
+                ],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                param0: {
+                    let mut result = [0u8; 32];
+                    let v = values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_fixed_bytes()
+                        .expect(INTERNAL_ERR);
+                    result.copy_from_slice(&v);
+                    result
+                },
+                param1: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                param2: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                param3: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                param4: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_array()
+                    .expect(INTERNAL_ERR)
+                    .into_iter()
+                    .map(|inner| {
+                        let mut v = [0 as u8; 32];
+                        inner
+                            .into_uint()
+                            .expect(INTERNAL_ERR)
+                            .to_big_endian(v.as_mut_slice());
+                        substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                    })
+                    .collect(),
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::FixedBytes(self.param0.as_ref().to_vec()),
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.param1)),
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.param2)),
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self.param3.clone().to_bytes_be() {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+                {
+                    let v = self
+                        .param4
+                        .iter()
+                        .map(|inner| {
+                            ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                                match inner.clone().to_bytes_be() {
+                                    (num_bigint::Sign::Plus, bytes) => bytes,
+                                    (num_bigint::Sign::NoSign, bytes) => bytes,
+                                    (num_bigint::Sign::Minus, _) => {
+                                        panic!("negative numbers are not supported")
+                                    }
+                                }
+                                .as_slice(),
+                            ))
+                        })
+                        .collect();
+                    ethabi::Token::Array(v)
+                },
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<Vec<(substreams::scalar::BigInt, substreams::scalar::BigInt)>, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(
+            data: &[u8],
+        ) -> Result<Vec<(substreams::scalar::BigInt, substreams::scalar::BigInt)>, String> {
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Array(Box::new(ethabi::ParamType::Tuple(vec![
+                    ethabi::ParamType::Uint(256usize),
+                    ethabi::ParamType::Uint(256usize),
+                ])))],
+                data.as_ref(),
+            )
+            .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok(values
+                .pop()
+                .expect("one output data should have existed")
+                .into_array()
+                .expect(INTERNAL_ERR)
+                .into_iter()
+                .map(|inner| {
+                    let tuple_elements = inner.into_tuple().expect(INTERNAL_ERR);
+                    (
+                        {
+                            let mut v = [0 as u8; 32];
+                            tuple_elements[0usize]
+                                .clone()
+                                .into_uint()
+                                .expect(INTERNAL_ERR)
+                                .to_big_endian(v.as_mut_slice());
+                            substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                        },
+                        {
+                            let mut v = [0 as u8; 32];
+                            tuple_elements[1usize]
+                                .clone()
+                                .into_uint()
+                                .expect(INTERNAL_ERR)
+                                .to_big_endian(v.as_mut_slice());
+                            substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                        },
+                    )
+                })
+                .collect())
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(
+            &self,
+            address: Vec<u8>,
+        ) -> Option<Vec<(substreams::scalar::BigInt, substreams::scalar::BigInt)>> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for PriceDerivative {
+        const NAME: &'static str = "priceDerivative";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl
+        substreams_ethereum::rpc::RPCDecodable<
+            Vec<(substreams::scalar::BigInt, substreams::scalar::BigInt)>,
+        > for PriceDerivative
+    {
+        fn output(
+            data: &[u8],
+        ) -> Result<Vec<(substreams::scalar::BigInt, substreams::scalar::BigInt)>, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct ProxiableUuid {}
+    impl ProxiableUuid {
+        const METHOD_ID: [u8; 4] = [82u8, 209u8, 144u8, 45u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Ok(Self {})
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<[u8; 32usize], String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<[u8; 32usize], String> {
+            let mut values =
+                ethabi::decode(&[ethabi::ParamType::FixedBytes(32usize)], data.as_ref())
+                    .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok({
+                let mut result = [0u8; 32];
+                let v = values
+                    .pop()
+                    .expect("one output data should have existed")
+                    .into_fixed_bytes()
+                    .expect(INTERNAL_ERR);
+                result.copy_from_slice(&v);
+                result
+            })
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<[u8; 32usize]> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for ProxiableUuid {
+        const NAME: &'static str = "proxiableUUID";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<[u8; 32usize]> for ProxiableUuid {
+        fn output(data: &[u8]) -> Result<[u8; 32usize], String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct RenounceOwnership {}
+    impl RenounceOwnership {
+        const METHOD_ID: [u8; 4] = [113u8, 80u8, 24u8, 166u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Ok(Self {})
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+    }
+    impl substreams_ethereum::Function for RenounceOwnership {
+        const NAME: &'static str = "renounceOwnership";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Rescue {
+        pub token: Vec<u8>,
+        pub amount: substreams::scalar::BigInt,
+    }
+    impl Rescue {
+        const METHOD_ID: [u8; 4] = [122u8, 78u8, 78u8, 207u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Address, ethabi::ParamType::Uint(256usize)],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                token: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                amount: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.token)),
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self.amount.clone().to_bytes_be() {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Rescue {
+        const NAME: &'static str = "rescue";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Router {}
+    impl Router {
+        const METHOD_ID: [u8; 4] = [248u8, 135u8, 234u8, 64u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Ok(Self {})
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<Vec<u8>, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<Vec<u8>, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Address], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok(values
+                .pop()
+                .expect("one output data should have existed")
+                .into_address()
+                .expect(INTERNAL_ERR)
+                .as_bytes()
+                .to_vec())
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<Vec<u8>> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Router {
+        const NAME: &'static str = "router";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<Vec<u8>> for Router {
+        fn output(data: &[u8]) -> Result<Vec<u8>, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct SetIndexer {
+        pub indexer: Vec<u8>,
+    }
+    impl SetIndexer {
+        const METHOD_ID: [u8; 4] = [59u8, 67u8, 30u8, 146u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(&[ethabi::ParamType::Address], maybe_data.unwrap())
+                .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                indexer: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[ethabi::Token::Address(ethabi::Address::from_slice(
+                &self.indexer,
+            ))]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+    }
+    impl substreams_ethereum::Function for SetIndexer {
+        const NAME: &'static str = "setIndexer";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct SetLegacyPod {
+        pub pod: Vec<u8>,
+        pub is_legacy: bool,
+    }
+    impl SetLegacyPod {
+        const METHOD_ID: [u8; 4] = [102u8, 214u8, 45u8, 151u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Address, ethabi::ParamType::Bool],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                pod: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                is_legacy: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_bool()
+                    .expect(INTERNAL_ERR),
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.pod)),
+                ethabi::Token::Bool(self.is_legacy.clone()),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+    }
+    impl substreams_ethereum::Function for SetLegacyPod {
+        const NAME: &'static str = "setLegacyPod";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct SetLeverageManager {
+        pub leverage_manager: Vec<u8>,
+    }
+    impl SetLeverageManager {
+        const METHOD_ID: [u8; 4] = [243u8, 4u8, 194u8, 120u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(&[ethabi::ParamType::Address], maybe_data.unwrap())
+                .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                leverage_manager: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[ethabi::Token::Address(ethabi::Address::from_slice(
+                &self.leverage_manager,
+            ))]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+    }
+    impl substreams_ethereum::Function for SetLeverageManager {
+        const NAME: &'static str = "setLeverageManager";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct SetRouter {
+        pub router: Vec<u8>,
+    }
+    impl SetRouter {
+        const METHOD_ID: [u8; 4] = [192u8, 215u8, 134u8, 85u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(&[ethabi::ParamType::Address], maybe_data.unwrap())
+                .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                router: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[ethabi::Token::Address(ethabi::Address::from_slice(
+                &self.router,
+            ))]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+    }
+    impl substreams_ethereum::Function for SetRouter {
+        const NAME: &'static str = "setRouter";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Swap1 {
+        pub param0: [u8; 32usize],
+        pub sell_token: Vec<u8>,
+        pub buy_token: Vec<u8>,
+        pub side: substreams::scalar::BigInt,
+        pub specified_amount: substreams::scalar::BigInt,
+        pub limit_amount: substreams::scalar::BigInt,
+    }
+    impl Swap1 {
+        const METHOD_ID: [u8; 4] = [55u8, 158u8, 143u8, 30u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[
+                    ethabi::ParamType::FixedBytes(32usize),
+                    ethabi::ParamType::Address,
+                    ethabi::ParamType::Address,
+                    ethabi::ParamType::Uint(8usize),
+                    ethabi::ParamType::Uint(256usize),
+                    ethabi::ParamType::Uint(256usize),
+                ],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                param0: {
+                    let mut result = [0u8; 32];
+                    let v = values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_fixed_bytes()
+                        .expect(INTERNAL_ERR);
+                    result.copy_from_slice(&v);
+                    result
+                },
+                sell_token: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                buy_token: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                side: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                specified_amount: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                limit_amount: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::FixedBytes(self.param0.as_ref().to_vec()),
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.sell_token)),
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.buy_token)),
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self.side.clone().to_bytes_be() {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self
+                        .specified_amount
+                        .clone()
+                        .to_bytes_be()
+                    {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self.limit_amount.clone().to_bytes_be() {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<
+            (
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+                (substreams::scalar::BigInt, substreams::scalar::BigInt),
+            ),
+            String,
+        > {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(
+            data: &[u8],
+        ) -> Result<
+            (
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+                (substreams::scalar::BigInt, substreams::scalar::BigInt),
+            ),
+            String,
+        > {
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Tuple(vec![
+                    ethabi::ParamType::Uint(256usize),
+                    ethabi::ParamType::Uint(256usize),
+                    ethabi::ParamType::Tuple(vec![
+                        ethabi::ParamType::Uint(256usize),
+                        ethabi::ParamType::Uint(256usize),
+                    ]),
+                ])],
+                data.as_ref(),
+            )
+            .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok({
+                let tuple_elements = values
+                    .pop()
+                    .expect("one output data should have existed")
+                    .into_tuple()
+                    .expect(INTERNAL_ERR);
+                (
+                    {
+                        let mut v = [0 as u8; 32];
+                        tuple_elements[0usize]
+                            .clone()
+                            .into_uint()
+                            .expect(INTERNAL_ERR)
+                            .to_big_endian(v.as_mut_slice());
+                        substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                    },
+                    {
+                        let mut v = [0 as u8; 32];
+                        tuple_elements[1usize]
+                            .clone()
+                            .into_uint()
+                            .expect(INTERNAL_ERR)
+                            .to_big_endian(v.as_mut_slice());
+                        substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                    },
+                    {
+                        let tuple_elements = tuple_elements[2usize]
+                            .clone()
+                            .into_tuple()
+                            .expect(INTERNAL_ERR);
+                        (
+                            {
+                                let mut v = [0 as u8; 32];
+                                tuple_elements[0usize]
+                                    .clone()
+                                    .into_uint()
+                                    .expect(INTERNAL_ERR)
+                                    .to_big_endian(v.as_mut_slice());
+                                substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                            },
+                            {
+                                let mut v = [0 as u8; 32];
+                                tuple_elements[1usize]
+                                    .clone()
+                                    .into_uint()
+                                    .expect(INTERNAL_ERR)
+                                    .to_big_endian(v.as_mut_slice());
+                                substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                            },
+                        )
+                    },
+                )
+            })
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(
+            &self,
+            address: Vec<u8>,
+        ) -> Option<(
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+            (substreams::scalar::BigInt, substreams::scalar::BigInt),
+        )> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Swap1 {
+        const NAME: &'static str = "swap";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl
+        substreams_ethereum::rpc::RPCDecodable<(
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+            (substreams::scalar::BigInt, substreams::scalar::BigInt),
+        )> for Swap1
+    {
+        fn output(
+            data: &[u8],
+        ) -> Result<
+            (
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+                (substreams::scalar::BigInt, substreams::scalar::BigInt),
+            ),
+            String,
+        > {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Swap2 {
+        pub param0: [u8; 32usize],
+        pub sell_token: Vec<u8>,
+        pub buy_token: Vec<u8>,
+        pub side: substreams::scalar::BigInt,
+        pub specified_amount: substreams::scalar::BigInt,
+    }
+    impl Swap2 {
+        const METHOD_ID: [u8; 4] = [131u8, 7u8, 198u8, 85u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[
+                    ethabi::ParamType::FixedBytes(32usize),
+                    ethabi::ParamType::Address,
+                    ethabi::ParamType::Address,
+                    ethabi::ParamType::Uint(8usize),
+                    ethabi::ParamType::Uint(256usize),
+                ],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                param0: {
+                    let mut result = [0u8; 32];
+                    let v = values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_fixed_bytes()
+                        .expect(INTERNAL_ERR);
+                    result.copy_from_slice(&v);
+                    result
+                },
+                sell_token: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                buy_token: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                side: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                specified_amount: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::FixedBytes(self.param0.as_ref().to_vec()),
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.sell_token)),
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.buy_token)),
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self.side.clone().to_bytes_be() {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self
+                        .specified_amount
+                        .clone()
+                        .to_bytes_be()
+                    {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<
+            (
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+                (substreams::scalar::BigInt, substreams::scalar::BigInt),
+            ),
+            String,
+        > {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(
+            data: &[u8],
+        ) -> Result<
+            (
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+                (substreams::scalar::BigInt, substreams::scalar::BigInt),
+            ),
+            String,
+        > {
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Tuple(vec![
+                    ethabi::ParamType::Uint(256usize),
+                    ethabi::ParamType::Uint(256usize),
+                    ethabi::ParamType::Tuple(vec![
+                        ethabi::ParamType::Uint(256usize),
+                        ethabi::ParamType::Uint(256usize),
+                    ]),
+                ])],
+                data.as_ref(),
+            )
+            .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok({
+                let tuple_elements = values
+                    .pop()
+                    .expect("one output data should have existed")
+                    .into_tuple()
+                    .expect(INTERNAL_ERR);
+                (
+                    {
+                        let mut v = [0 as u8; 32];
+                        tuple_elements[0usize]
+                            .clone()
+                            .into_uint()
+                            .expect(INTERNAL_ERR)
+                            .to_big_endian(v.as_mut_slice());
+                        substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                    },
+                    {
+                        let mut v = [0 as u8; 32];
+                        tuple_elements[1usize]
+                            .clone()
+                            .into_uint()
+                            .expect(INTERNAL_ERR)
+                            .to_big_endian(v.as_mut_slice());
+                        substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                    },
+                    {
+                        let tuple_elements = tuple_elements[2usize]
+                            .clone()
+                            .into_tuple()
+                            .expect(INTERNAL_ERR);
+                        (
+                            {
+                                let mut v = [0 as u8; 32];
+                                tuple_elements[0usize]
+                                    .clone()
+                                    .into_uint()
+                                    .expect(INTERNAL_ERR)
+                                    .to_big_endian(v.as_mut_slice());
+                                substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                            },
+                            {
+                                let mut v = [0 as u8; 32];
+                                tuple_elements[1usize]
+                                    .clone()
+                                    .into_uint()
+                                    .expect(INTERNAL_ERR)
+                                    .to_big_endian(v.as_mut_slice());
+                                substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                            },
+                        )
+                    },
+                )
+            })
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(
+            &self,
+            address: Vec<u8>,
+        ) -> Option<(
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+            (substreams::scalar::BigInt, substreams::scalar::BigInt),
+        )> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Swap2 {
+        const NAME: &'static str = "swap";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl
+        substreams_ethereum::rpc::RPCDecodable<(
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+            (substreams::scalar::BigInt, substreams::scalar::BigInt),
+        )> for Swap2
+    {
+        fn output(
+            data: &[u8],
+        ) -> Result<
+            (
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+                (substreams::scalar::BigInt, substreams::scalar::BigInt),
+            ),
+            String,
+        > {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct SwapToPrice {
+        pub pool_id: [u8; 32usize],
+        pub sell_token: Vec<u8>,
+        pub buy_token: Vec<u8>,
+        pub limit_price: (substreams::scalar::BigInt, substreams::scalar::BigInt),
+    }
+    impl SwapToPrice {
+        const METHOD_ID: [u8; 4] = [46u8, 245u8, 29u8, 72u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[
+                    ethabi::ParamType::FixedBytes(32usize),
+                    ethabi::ParamType::Address,
+                    ethabi::ParamType::Address,
+                    ethabi::ParamType::Tuple(vec![
+                        ethabi::ParamType::Uint(256usize),
+                        ethabi::ParamType::Uint(256usize),
+                    ]),
+                ],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                pool_id: {
+                    let mut result = [0u8; 32];
+                    let v = values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_fixed_bytes()
+                        .expect(INTERNAL_ERR);
+                    result.copy_from_slice(&v);
+                    result
+                },
+                sell_token: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                buy_token: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                limit_price: {
+                    let tuple_elements = values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_tuple()
+                        .expect(INTERNAL_ERR);
+                    (
+                        {
+                            let mut v = [0 as u8; 32];
+                            tuple_elements[0usize]
+                                .clone()
+                                .into_uint()
+                                .expect(INTERNAL_ERR)
+                                .to_big_endian(v.as_mut_slice());
+                            substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                        },
+                        {
+                            let mut v = [0 as u8; 32];
+                            tuple_elements[1usize]
+                                .clone()
+                                .into_uint()
+                                .expect(INTERNAL_ERR)
+                                .to_big_endian(v.as_mut_slice());
+                            substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                        },
+                    )
+                },
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::FixedBytes(self.pool_id.as_ref().to_vec()),
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.sell_token)),
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.buy_token)),
+                ethabi::Token::Tuple(vec![
+                    ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                        match self.limit_price.0.clone().to_bytes_be() {
+                            (num_bigint::Sign::Plus, bytes) => bytes,
+                            (num_bigint::Sign::NoSign, bytes) => bytes,
+                            (num_bigint::Sign::Minus, _) => {
+                                panic!("negative numbers are not supported")
+                            }
+                        }
+                        .as_slice(),
+                    )),
+                    ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                        match self.limit_price.1.clone().to_bytes_be() {
+                            (num_bigint::Sign::Plus, bytes) => bytes,
+                            (num_bigint::Sign::NoSign, bytes) => bytes,
+                            (num_bigint::Sign::Minus, _) => {
+                                panic!("negative numbers are not supported")
+                            }
+                        }
+                        .as_slice(),
+                    )),
+                ]),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<
+            (
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+                (substreams::scalar::BigInt, substreams::scalar::BigInt),
+            ),
+            String,
+        > {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(
+            data: &[u8],
+        ) -> Result<
+            (
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+                (substreams::scalar::BigInt, substreams::scalar::BigInt),
+            ),
+            String,
+        > {
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Tuple(vec![
+                    ethabi::ParamType::Uint(256usize),
+                    ethabi::ParamType::Uint(256usize),
+                    ethabi::ParamType::Tuple(vec![
+                        ethabi::ParamType::Uint(256usize),
+                        ethabi::ParamType::Uint(256usize),
+                    ]),
+                ])],
+                data.as_ref(),
+            )
+            .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok({
+                let tuple_elements = values
+                    .pop()
+                    .expect("one output data should have existed")
+                    .into_tuple()
+                    .expect(INTERNAL_ERR);
+                (
+                    {
+                        let mut v = [0 as u8; 32];
+                        tuple_elements[0usize]
+                            .clone()
+                            .into_uint()
+                            .expect(INTERNAL_ERR)
+                            .to_big_endian(v.as_mut_slice());
+                        substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                    },
+                    {
+                        let mut v = [0 as u8; 32];
+                        tuple_elements[1usize]
+                            .clone()
+                            .into_uint()
+                            .expect(INTERNAL_ERR)
+                            .to_big_endian(v.as_mut_slice());
+                        substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                    },
+                    {
+                        let tuple_elements = tuple_elements[2usize]
+                            .clone()
+                            .into_tuple()
+                            .expect(INTERNAL_ERR);
+                        (
+                            {
+                                let mut v = [0 as u8; 32];
+                                tuple_elements[0usize]
+                                    .clone()
+                                    .into_uint()
+                                    .expect(INTERNAL_ERR)
+                                    .to_big_endian(v.as_mut_slice());
+                                substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                            },
+                            {
+                                let mut v = [0 as u8; 32];
+                                tuple_elements[1usize]
+                                    .clone()
+                                    .into_uint()
+                                    .expect(INTERNAL_ERR)
+                                    .to_big_endian(v.as_mut_slice());
+                                substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                            },
+                        )
+                    },
+                )
+            })
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(
+            &self,
+            address: Vec<u8>,
+        ) -> Option<(
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+            (substreams::scalar::BigInt, substreams::scalar::BigInt),
+        )> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for SwapToPrice {
+        const NAME: &'static str = "swapToPrice";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl
+        substreams_ethereum::rpc::RPCDecodable<(
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+            (substreams::scalar::BigInt, substreams::scalar::BigInt),
+        )> for SwapToPrice
+    {
+        fn output(
+            data: &[u8],
+        ) -> Result<
+            (
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+                (substreams::scalar::BigInt, substreams::scalar::BigInt),
+            ),
+            String,
+        > {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct TransferOwnership {
+        pub new_owner: Vec<u8>,
+    }
+    impl TransferOwnership {
+        const METHOD_ID: [u8; 4] = [242u8, 253u8, 227u8, 139u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(&[ethabi::ParamType::Address], maybe_data.unwrap())
+                .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                new_owner: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[ethabi::Token::Address(ethabi::Address::from_slice(
+                &self.new_owner,
+            ))]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+    }
+    impl substreams_ethereum::Function for TransferOwnership {
+        const NAME: &'static str = "transferOwnership";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct UpgradeInterfaceVersion {}
+    impl UpgradeInterfaceVersion {
+        const METHOD_ID: [u8; 4] = [173u8, 60u8, 177u8, 204u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Ok(Self {})
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<String, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<String, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::String], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok(values
+                .pop()
+                .expect("one output data should have existed")
+                .into_string()
+                .expect(INTERNAL_ERR))
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<String> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for UpgradeInterfaceVersion {
+        const NAME: &'static str = "UPGRADE_INTERFACE_VERSION";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<String> for UpgradeInterfaceVersion {
+        fn output(data: &[u8]) -> Result<String, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct UpgradeToAndCall {
+        pub new_implementation: Vec<u8>,
+        pub data: Vec<u8>,
+    }
+    impl UpgradeToAndCall {
+        const METHOD_ID: [u8; 4] = [79u8, 30u8, 242u8, 134u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Address, ethabi::ParamType::Bytes],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                new_implementation: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                data: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_bytes()
+                    .expect(INTERNAL_ERR),
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.new_implementation)),
+                ethabi::Token::Bytes(self.data.clone()),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+    }
+    impl substreams_ethereum::Function for UpgradeToAndCall {
+        const NAME: &'static str = "upgradeToAndCall";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+}
+/// Contract's events.
+#[allow(dead_code, unused_imports, unused_variables)]
+pub mod events {
+    use super::INTERNAL_ERR;
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Initialized {
+        pub version: substreams::scalar::BigInt,
+    }
+    impl Initialized {
+        const TOPIC_ID: [u8; 32] = [
+            199u8, 245u8, 5u8, 178u8, 243u8, 113u8, 174u8, 33u8, 117u8, 238u8, 73u8, 19u8, 244u8,
+            73u8, 158u8, 31u8, 38u8, 51u8, 167u8, 181u8, 147u8, 99u8, 33u8, 238u8, 209u8, 205u8,
+            174u8, 182u8, 17u8, 81u8, 129u8, 210u8,
+        ];
+        pub fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            if log.topics.len() != 1usize {
+                return false;
+            }
+            if log.data.len() != 32usize {
+                return false;
+            }
+            return log
+                .topics
+                .get(0)
+                .expect("bounds already checked")
+                .as_ref()
+                == Self::TOPIC_ID;
+        }
+        pub fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Uint(64usize)], log.data.as_ref())
+                .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                version: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+    }
+    impl substreams_ethereum::Event for Initialized {
+        const NAME: &'static str = "Initialized";
+        fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            Self::match_log(log)
+        }
+        fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            Self::decode(log)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct OwnershipTransferStarted {
+        pub previous_owner: Vec<u8>,
+        pub new_owner: Vec<u8>,
+    }
+    impl OwnershipTransferStarted {
+        const TOPIC_ID: [u8; 32] = [
+            56u8, 209u8, 107u8, 140u8, 172u8, 34u8, 217u8, 159u8, 199u8, 193u8, 36u8, 185u8, 205u8,
+            13u8, 226u8, 211u8, 250u8, 31u8, 174u8, 244u8, 32u8, 191u8, 231u8, 145u8, 216u8, 195u8,
+            98u8, 215u8, 101u8, 226u8, 39u8, 0u8,
+        ];
+        pub fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            if log.topics.len() != 3usize {
+                return false;
+            }
+            if log.data.len() != 0usize {
+                return false;
+            }
+            return log
+                .topics
+                .get(0)
+                .expect("bounds already checked")
+                .as_ref()
+                == Self::TOPIC_ID;
+        }
+        pub fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            Ok(Self {
+                previous_owner: ethabi::decode(
+                        &[ethabi::ParamType::Address],
+                        log.topics[1usize].as_ref(),
+                    )
+                    .map_err(|e| {
+                        format!(
+                            "unable to decode param 'previous_owner' from topic of type 'address': {:?}",
+                            e
+                        )
+                    })?
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                new_owner: ethabi::decode(
+                        &[ethabi::ParamType::Address],
+                        log.topics[2usize].as_ref(),
+                    )
+                    .map_err(|e| {
+                        format!(
+                            "unable to decode param 'new_owner' from topic of type 'address': {:?}",
+                            e
+                        )
+                    })?
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+            })
+        }
+    }
+    impl substreams_ethereum::Event for OwnershipTransferStarted {
+        const NAME: &'static str = "OwnershipTransferStarted";
+        fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            Self::match_log(log)
+        }
+        fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            Self::decode(log)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct OwnershipTransferred {
+        pub previous_owner: Vec<u8>,
+        pub new_owner: Vec<u8>,
+    }
+    impl OwnershipTransferred {
+        const TOPIC_ID: [u8; 32] = [
+            139u8, 224u8, 7u8, 156u8, 83u8, 22u8, 89u8, 20u8, 19u8, 68u8, 205u8, 31u8, 208u8,
+            164u8, 242u8, 132u8, 25u8, 73u8, 127u8, 151u8, 34u8, 163u8, 218u8, 175u8, 227u8, 180u8,
+            24u8, 111u8, 107u8, 100u8, 87u8, 224u8,
+        ];
+        pub fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            if log.topics.len() != 3usize {
+                return false;
+            }
+            if log.data.len() != 0usize {
+                return false;
+            }
+            return log
+                .topics
+                .get(0)
+                .expect("bounds already checked")
+                .as_ref()
+                == Self::TOPIC_ID;
+        }
+        pub fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            Ok(Self {
+                previous_owner: ethabi::decode(
+                        &[ethabi::ParamType::Address],
+                        log.topics[1usize].as_ref(),
+                    )
+                    .map_err(|e| {
+                        format!(
+                            "unable to decode param 'previous_owner' from topic of type 'address': {:?}",
+                            e
+                        )
+                    })?
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                new_owner: ethabi::decode(
+                        &[ethabi::ParamType::Address],
+                        log.topics[2usize].as_ref(),
+                    )
+                    .map_err(|e| {
+                        format!(
+                            "unable to decode param 'new_owner' from topic of type 'address': {:?}",
+                            e
+                        )
+                    })?
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+            })
+        }
+    }
+    impl substreams_ethereum::Event for OwnershipTransferred {
+        const NAME: &'static str = "OwnershipTransferred";
+        fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            Self::match_log(log)
+        }
+        fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            Self::decode(log)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Upgraded {
+        pub implementation: Vec<u8>,
+    }
+    impl Upgraded {
+        const TOPIC_ID: [u8; 32] = [
+            188u8, 124u8, 215u8, 90u8, 32u8, 238u8, 39u8, 253u8, 154u8, 222u8, 186u8, 179u8, 32u8,
+            65u8, 247u8, 85u8, 33u8, 77u8, 188u8, 107u8, 255u8, 169u8, 12u8, 192u8, 34u8, 91u8,
+            57u8, 218u8, 46u8, 92u8, 45u8, 59u8,
+        ];
+        pub fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            if log.topics.len() != 2usize {
+                return false;
+            }
+            if log.data.len() != 0usize {
+                return false;
+            }
+            return log
+                .topics
+                .get(0)
+                .expect("bounds already checked")
+                .as_ref()
+                == Self::TOPIC_ID;
+        }
+        pub fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            Ok(Self {
+                implementation: ethabi::decode(
+                        &[ethabi::ParamType::Address],
+                        log.topics[1usize].as_ref(),
+                    )
+                    .map_err(|e| {
+                        format!(
+                            "unable to decode param 'implementation' from topic of type 'address': {:?}",
+                            e
+                        )
+                    })?
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+            })
+        }
+    }
+    impl substreams_ethereum::Event for Upgraded {
+        const NAME: &'static str = "Upgraded";
+        fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            Self::match_log(log)
+        }
+        fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            Self::decode(log)
+        }
+    }
+}

--- a/substreams/ethereum-peapods/src/lib.rs
+++ b/substreams/ethereum-peapods/src/lib.rs
@@ -1,0 +1,3 @@
+mod abi;
+mod modules;
+mod pb;

--- a/substreams/ethereum-peapods/src/modules/1_map_function_calls.rs
+++ b/substreams/ethereum-peapods/src/modules/1_map_function_calls.rs
@@ -1,0 +1,148 @@
+use crate::abi::swap_adapter::functions::{Price, Swap2, SwapToPrice};
+use crate::pb::adapter::v1::function_call::CallType;
+use crate::pb::adapter::v1::*;
+use substreams_ethereum::pb::eth;
+
+use super::config::DeploymentConfig;
+use super::helper_funcs::{canonicalize_addresses, format_address, key_from_tokens};
+
+#[substreams::handlers::map]
+pub fn map_function_calls(
+    params: String, // adapter address in hex form
+    block: eth::v2::Block,
+) -> Result<FunctionCalls, anyhow::Error> {
+    // Decode adapter address from parameters.
+    let config: DeploymentConfig = serde_qs::from_str(params.as_str())?;
+    let adapter_address = config.adapter_address;
+
+    let mut func_calls = FunctionCalls { calls: vec![] };
+
+    for tx in block.transactions() {
+        // Iterate over the internal calls in the transaction.
+        let fn_calls: Vec<FunctionCall> = tx
+            .calls()
+            // Filter calls directed to our adapter contract.
+            .filter(|call| call.transaction.to == adapter_address)
+            .filter(|call| !call.call.state_reverted)
+            .filter_map(|call| {
+                // Depending on the function selector, identify the call type.
+                if Swap2::match_call(call.call) {
+                    let swap_call = Swap2::decode(call.call).unwrap();
+                    let result = Swap2::output_call(call.call).unwrap();
+
+                    let price = result.2 .0.to_string();
+                    let trade = Trade {
+                        calculated_amount: result.0.to_string(),
+                        gas_used: result.1.to_string(),
+                        marginal_price_after_trade: price,
+                    };
+
+                    let (addr0, addr1) = canonicalize_addresses(
+                        swap_call.sell_token.clone(),
+                        swap_call.buy_token.clone(),
+                    );
+                    let call_id = key_from_tokens(&addr0, &addr1);
+                    let sell_token_addr = format_address(&swap_call.sell_token);
+                    let buy_token_addr = format_address(&swap_call.buy_token);
+
+                    Some(FunctionCall {
+                        id: call_id,
+                        sell_token: sell_token_addr,
+                        buy_token: buy_token_addr,
+                        transaction: Some(Transaction {
+                            hash: call.transaction.hash.clone(),
+                            from: call.transaction.from.clone(),
+                            to: call.transaction.to.clone(),
+                            index: call.transaction.index,
+                        }),
+                        call_type: Some(CallType::Swap(SwapCallData {
+                            side: swap_call.side.to_i32(),
+                            specified_amount: swap_call.specified_amount.to_u64(),
+                            result: Some(trade),
+                        })),
+                    })
+                } else if SwapToPrice::match_call(&call.call) {
+                    let swap_to_price_call = SwapToPrice::decode(call.call).unwrap();
+                    let result = SwapToPrice::output_call(call.call).unwrap();
+                    let price = result.2 .0.to_string();
+                    let trade = Trade {
+                        calculated_amount: result.0.to_string(),
+                        gas_used: result.1.to_string(),
+                        marginal_price_after_trade: price,
+                    };
+
+                    let (addr0, addr1) = canonicalize_addresses(
+                        swap_to_price_call.sell_token.clone(),
+                        swap_to_price_call.buy_token.clone(),
+                    );
+
+                    let call_id = key_from_tokens(&addr0, &addr1);
+                    let sell_token_addr = format_address(&swap_to_price_call.sell_token);
+                    let buy_token_addr = format_address(&swap_to_price_call.buy_token);
+
+                    Some(FunctionCall {
+                        id: call_id,
+                        sell_token: sell_token_addr,
+                        buy_token: buy_token_addr,
+                        transaction: Some(Transaction {
+                            hash: call.transaction.hash.clone(),
+                            from: call.transaction.from.clone(),
+                            to: call.transaction.to.clone(),
+                            index: call.transaction.index,
+                        }),
+                        call_type: Some(CallType::SwapToPrice(SwapToPriceCallData {
+                            limit_price: swap_to_price_call
+                                .limit_price
+                                .0
+                                .to_string(),
+                            result: Some(trade),
+                        })),
+                    })
+                } else if Price::match_call(&call.call) {
+                    let price_call = Price::decode(call.call).unwrap();
+                    let result = Price::output_call(call.call).unwrap();
+
+                    let specified_amounts = price_call
+                        .specified_amounts
+                        .iter()
+                        .map(|amount| amount.to_bytes_be().1)
+                        .collect();
+                    let prices = result
+                        .iter()
+                        .map(|price| price.0.to_string())
+                        .collect();
+
+                    let (addr0, addr1) = canonicalize_addresses(
+                        price_call.sell_token.clone(),
+                        price_call.buy_token.clone(),
+                    );
+                    let call_id = key_from_tokens(&addr0, &addr1);
+                    let sell_token_addr = format_address(&price_call.sell_token);
+                    let buy_token_addr = format_address(&price_call.buy_token);
+
+                    Some(FunctionCall {
+                        id: call_id,
+                        sell_token: sell_token_addr,
+                        buy_token: buy_token_addr,
+                        transaction: Some(Transaction {
+                            hash: call.transaction.hash.clone(),
+                            from: call.transaction.from.clone(),
+                            to: call.transaction.to.clone(),
+                            index: call.transaction.index,
+                        }),
+                        call_type: Some(CallType::Price(PriceCallData {
+                            specified_amounts,
+                            prices,
+                        })),
+                    })
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        func_calls.calls.extend(fn_calls);
+    }
+
+    Ok(func_calls)
+}

--- a/substreams/ethereum-peapods/src/modules/2_store_exchange_price.rs
+++ b/substreams/ethereum-peapods/src/modules/2_store_exchange_price.rs
@@ -1,0 +1,97 @@
+use prost::Message;
+use substreams::store::*;
+
+use crate::pb::adapter::v1::{function_call::CallType, *};
+
+use super::helper_funcs::{canonicalize_addresses, compute_exchange_price};
+
+#[substreams::handlers::store]
+pub fn store_exchange_price(func_calls: FunctionCalls, store: StoreSetBigInt) {
+    // Map token pairs from function calls
+    for call in func_calls.calls {
+        match call.call_type {
+            Some(CallType::Swap(swap_call_data)) => {
+                let (token0, _) = canonicalize_addresses(
+                    call.sell_token.encode_to_vec(),
+                    call.buy_token.encode_to_vec(),
+                );
+
+                store.set(
+                    0,
+                    call.id,
+                    &compute_exchange_price(
+                        token0.clone(),
+                        call.sell_token.encode_to_vec(),
+                        swap_call_data
+                            .result
+                            .expect("No Trade result")
+                            .marginal_price_after_trade,
+                    ),
+                );
+            }
+            Some(CallType::SwapToPrice(swap_to_price_call_data)) => {
+                let (token0, _) = canonicalize_addresses(
+                    call.sell_token.encode_to_vec(),
+                    call.buy_token.encode_to_vec(),
+                );
+
+                store.set(
+                    0,
+                    call.id,
+                    &compute_exchange_price(
+                        token0.clone(),
+                        call.sell_token.encode_to_vec(),
+                        swap_to_price_call_data
+                            .result
+                            .expect("No Trade result")
+                            .marginal_price_after_trade,
+                    ),
+                );
+            }
+            // Skip Price call because it is a view func and we can't get view func calls from the block
+            // Some(CallType::Price(price_call_data)) => {
+            //     let (token0, _) = canonicalize_addresses(
+            //         call.sell_token.encode_to_vec(),
+            //         call.buy_token.encode_to_vec(),
+            //     );
+
+            //     let last_price = price_call_data
+            //         .prices
+            //         .last()
+            //         .expect("No price at the last index of prices");
+            //     let last_specified_amount = price_call_data
+            //         .specified_amounts
+            //         .last()
+            //         .expect("No specified amount at the last index of specified amounts");
+
+            //     let denominator = U256::from_big_endian(&last_price.denominator);
+            //     let specified_amount = U256::from_big_endian(last_specified_amount);
+
+            //     // Perform multiplication safely with U256
+            //     let new_denominator = denominator
+            //         .checked_mul(specified_amount)
+            //         .expect("Multiplication overflow");
+
+            //     let actual_price = Fraction {
+            //         numerator: last_price.numerator.clone(),
+            //         denominator: {
+            //             let mut result = vec![0u8; 32];
+            //             new_denominator.to_big_endian(&mut result);
+            //             result
+            //         },
+            //     };
+
+            //     store.set(
+            //         0,
+            //         call.id,
+            //         &compute_exchange_price(
+            //             token0.clone(),
+            //             call.sell_token.encode_to_vec(),
+            //             actual_price,
+            //         ),
+            //     );
+            // }
+            _ => {}
+        }
+    }
+}

--- a/substreams/ethereum-peapods/src/modules/3_map_token_pairs.rs
+++ b/substreams/ethereum-peapods/src/modules/3_map_token_pairs.rs
@@ -1,0 +1,166 @@
+use std::collections::HashMap;
+use substreams_ethereum::pb::eth;
+use tycho_substreams::models::{
+    BlockTransactionProtocolComponents, ChangeType, FinancialType, ImplementationType,
+    ProtocolComponent, ProtocolType, Transaction, TransactionProtocolComponents,
+};
+
+use crate::abi::swap_adapter::functions::{Price, Swap2, SwapToPrice};
+
+use super::{
+    config::DeploymentConfig,
+    helper_funcs::{canonicalize_addresses, key_from_tokens},
+};
+
+struct ProtocolComponentWithTransaction {
+    proto_comp: ProtocolComponent,
+    tx: Transaction,
+}
+
+#[substreams::handlers::map]
+/// Find and create all relevant protocol components
+///
+/// This method maps over blocks and instantiates ProtocolComponents with a unique ids
+/// as well as all necessary metadata for routing and encoding.
+#[substreams::handlers::map]
+fn map_token_pairs(
+    params: String, // adapter address in hex form
+    block: eth::v2::Block,
+) -> Result<BlockTransactionProtocolComponents, anyhow::Error> {
+    // Decode adapter address from parameters.
+    let config: DeploymentConfig = serde_qs::from_str(params.as_str())?;
+    let adapter_address = config.adapter_address;
+
+    let mut proto_comp_with_txn: HashMap<String, ProtocolComponentWithTransaction> = HashMap::new();
+
+    for tx in block.transactions() {
+        // Iterate over the internal calls in the transaction.
+        tx.calls()
+            // Filter calls directed to our adapter contract.
+            .filter(|call| call.transaction.to == adapter_address)
+            .filter(|call| !call.call.state_reverted)
+            .for_each(|call| {
+                if Swap2::match_call(call.call) {
+                    let swap_call = Swap2::decode(call.call).unwrap();
+                    let (addr0, addr1) = canonicalize_addresses(
+                        swap_call.sell_token.clone(),
+                        swap_call.buy_token.clone(),
+                    );
+                    let component_id = key_from_tokens(&addr0, &addr1);
+
+                    if proto_comp_with_txn.contains_key(&component_id) {
+                        return;
+                    }
+
+                    proto_comp_with_txn.insert(
+                        component_id.clone(),
+                        ProtocolComponentWithTransaction {
+                            proto_comp: ProtocolComponent {
+                                id: component_id,
+                                tokens: vec![addr0, addr1],
+                                contracts: vec![adapter_address.clone()],
+                                static_att: vec![],
+                                change: ChangeType::Creation.into(),
+                                protocol_type: Some(ProtocolType {
+                                    name: "Adapter Token Pair".to_string(),
+                                    financial_type: FinancialType::Swap.into(),
+                                    attribute_schema: vec![],
+                                    implementation_type: ImplementationType::Vm.into(),
+                                }),
+                            },
+                            tx: Transaction {
+                                hash: call.transaction.hash.clone(),
+                                from: call.transaction.from.clone(),
+                                to: call.transaction.to.clone(),
+                                index: call.transaction.index as u64,
+                            },
+                        },
+                    );
+                } else if SwapToPrice::match_call(&call.call) {
+                    let swap_to_price_call = SwapToPrice::decode(call.call).unwrap();
+                    let (addr0, addr1) = canonicalize_addresses(
+                        swap_to_price_call.sell_token.clone(),
+                        swap_to_price_call.buy_token.clone(),
+                    );
+                    let component_id = key_from_tokens(&addr0, &addr1);
+
+                    if proto_comp_with_txn.contains_key(&component_id) {
+                        return;
+                    }
+
+                    proto_comp_with_txn.insert(
+                        component_id.clone(),
+                        ProtocolComponentWithTransaction {
+                            proto_comp: ProtocolComponent {
+                                id: component_id,
+                                tokens: vec![addr0, addr1],
+                                contracts: vec![adapter_address.clone()],
+                                static_att: vec![],
+                                change: ChangeType::Creation.into(),
+                                protocol_type: Some(ProtocolType {
+                                    name: "Adapter Token Pair".to_string(),
+                                    financial_type: FinancialType::Swap.into(),
+                                    attribute_schema: vec![],
+                                    implementation_type: ImplementationType::Vm.into(),
+                                }),
+                            },
+                            tx: Transaction {
+                                hash: call.transaction.hash.clone(),
+                                from: call.transaction.from.clone(),
+                                to: call.transaction.to.clone(),
+                                index: call.transaction.index as u64,
+                            },
+                        },
+                    );
+                } else if Price::match_call(&call.call) {
+                    let price_call = Price::decode(call.call).unwrap();
+                    let (addr0, addr1) = canonicalize_addresses(
+                        price_call.sell_token.clone(),
+                        price_call.buy_token.clone(),
+                    );
+                    let component_id = key_from_tokens(&addr0, &addr1);
+
+                    if proto_comp_with_txn.contains_key(&component_id) {
+                        return;
+                    }
+
+                    proto_comp_with_txn.insert(
+                        component_id.clone(),
+                        ProtocolComponentWithTransaction {
+                            proto_comp: ProtocolComponent {
+                                id: component_id,
+                                tokens: vec![addr0, addr1],
+                                contracts: vec![adapter_address.clone()],
+                                static_att: vec![],
+                                change: ChangeType::Creation.into(),
+                                protocol_type: Some(ProtocolType {
+                                    name: "Adapter Token Pair".to_string(),
+                                    financial_type: FinancialType::Swap.into(),
+                                    attribute_schema: vec![],
+                                    implementation_type: ImplementationType::Vm.into(),
+                                }),
+                            },
+                            tx: Transaction {
+                                hash: call.transaction.hash.clone(),
+                                from: call.transaction.from.clone(),
+                                to: call.transaction.to.clone(),
+                                index: call.transaction.index as u64,
+                            },
+                        },
+                    );
+                } else {
+                    return;
+                }
+            });
+    }
+
+    let mut protocol_components: Vec<TransactionProtocolComponents> = vec![];
+    for (_, proto_comp_with_txn) in proto_comp_with_txn {
+        protocol_components.push(TransactionProtocolComponents {
+            components: vec![proto_comp_with_txn.proto_comp],
+            tx: Some(proto_comp_with_txn.tx),
+        });
+    }
+
+    Ok(BlockTransactionProtocolComponents { tx_components: protocol_components })
+}

--- a/substreams/ethereum-peapods/src/modules/4_store_token_pairs.rs
+++ b/substreams/ethereum-peapods/src/modules/4_store_token_pairs.rs
@@ -1,0 +1,15 @@
+use substreams::store::*;
+use tycho_substreams::models::{BlockTransactionProtocolComponents, ProtocolComponent};
+
+// sets the exchange price of token pairs in the store
+#[substreams::handlers::store]
+pub fn store_token_pairs(
+    token_pairs_proto_comp: BlockTransactionProtocolComponents,
+    store: StoreSetProto<ProtocolComponent>,
+) {
+    for tx_comp in token_pairs_proto_comp.tx_components {
+        for proto_comp in tx_comp.components {
+            store.set(0, proto_comp.id.clone(), &proto_comp);
+        }
+    }
+}

--- a/substreams/ethereum-peapods/src/modules/5_map_protocol_changes.rs
+++ b/substreams/ethereum-peapods/src/modules/5_map_protocol_changes.rs
@@ -1,0 +1,82 @@
+use itertools::Itertools;
+use std::{collections::HashMap, str::FromStr};
+use substreams::{pb::substreams::StoreDeltas, scalar::BigInt};
+use substreams_ethereum::pb::eth::v2::Block;
+use tycho_substreams::models::{
+    Attribute, BlockChanges, BlockTransactionProtocolComponents, ChangeType, EntityChanges,
+    Transaction, TransactionChangesBuilder,
+};
+
+use crate::pb::adapter::v1::FunctionCalls;
+
+#[substreams::handlers::map]
+pub fn map_protocol_changes(
+    block: Block,
+    func_calls: FunctionCalls,
+    token_pairs: BlockTransactionProtocolComponents,
+    exchange_price_deltas: StoreDeltas,
+) -> Result<BlockChanges, substreams::errors::Error> {
+    let mut transaction_changes: HashMap<_, TransactionChangesBuilder> = HashMap::new();
+
+    // Aggregate newly created components per tx
+    token_pairs
+        .tx_components
+        .iter()
+        .for_each(|tx_component| {
+            // initialise builder if not yet present for this tx
+            let tx = tx_component.tx.as_ref().unwrap();
+            let builder = transaction_changes
+                .entry(tx.index)
+                .or_insert_with(|| TransactionChangesBuilder::new(tx));
+
+            // iterate over individual components created within this tx
+            tx_component
+                .components
+                .iter()
+                .for_each(|component| {
+                    builder.add_protocol_component(component);
+                });
+        });
+
+    exchange_price_deltas
+        .deltas
+        .iter()
+        .zip(func_calls.calls)
+        .for_each(|(store_delta, call)| {
+            let new_value_bigint = BigInt::from_str(
+                String::from_utf8(store_delta.new_value.clone())
+                    .expect("error while converting a string from store delta")
+                    .as_str(),
+            )
+            .unwrap();
+            let tx = call.transaction.unwrap();
+            let builder = transaction_changes
+                .entry(tx.index as u64)
+                .or_insert_with(|| {
+                    TransactionChangesBuilder::new(&Transaction {
+                        hash: tx.hash.clone(),
+                        from: tx.from.clone(),
+                        to: tx.to.clone(),
+                        index: tx.index as u64,
+                    })
+                });
+
+            builder.add_entity_change(&EntityChanges {
+                component_id: call.id,
+                attributes: vec![Attribute {
+                    name: "price".to_string(),
+                    value: new_value_bigint.to_signed_bytes_be(),
+                    change: ChangeType::Update.into(),
+                }],
+            });
+        });
+
+    Ok(BlockChanges {
+        block: Some((&block).into()),
+        changes: transaction_changes
+            .drain()
+            .sorted_unstable_by_key(|(index, _)| *index)
+            .filter_map(|(_, builder)| builder.build())
+            .collect::<Vec<_>>(),
+    })
+}

--- a/substreams/ethereum-peapods/src/modules/config.rs
+++ b/substreams/ethereum-peapods/src/modules/config.rs
@@ -1,0 +1,7 @@
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+pub struct DeploymentConfig {
+    #[serde(with = "hex::serde")]
+    pub adapter_address: Vec<u8>,
+}

--- a/substreams/ethereum-peapods/src/modules/helper_funcs.rs
+++ b/substreams/ethereum-peapods/src/modules/helper_funcs.rs
@@ -1,0 +1,31 @@
+use std::str::FromStr;
+
+use substreams::scalar::BigInt;
+
+// --- Helper Functions ---
+/// Returns the two addresses in a canonical order.
+pub fn canonicalize_addresses(addr1: Vec<u8>, addr2: Vec<u8>) -> (Vec<u8>, Vec<u8>) {
+    // Using the default lexicographical order
+    if addr1 < addr2 {
+        (addr1, addr2)
+    } else {
+        (addr2, addr1)
+    }
+}
+
+// requires canonicalized addresses
+pub fn key_from_tokens(addr1: &Vec<u8>, addr2: &Vec<u8>) -> String {
+    format!("pool:0x{:}:0x{:}", hex::encode(addr1), hex::encode(addr2))
+}
+
+pub fn format_address(addr: &Vec<u8>) -> String {
+    format!("0x{:}", hex::encode(addr))
+}
+
+pub fn compute_exchange_price(token0: Vec<u8>, sell_token: Vec<u8>, price: String) -> BigInt {
+    if token0 == sell_token {
+        BigInt::from_str(&price).unwrap()
+    } else {
+        BigInt::from(1) / BigInt::from_str(&price).unwrap()
+    }
+}

--- a/substreams/ethereum-peapods/src/modules/mod.rs
+++ b/substreams/ethereum-peapods/src/modules/mod.rs
@@ -1,0 +1,16 @@
+#[path = "1_map_function_calls.rs"]
+mod map_function_calls;
+#[path = "2_store_exchange_price.rs"]
+mod store_exchange_price;
+
+#[path = "3_map_token_pairs.rs"]
+mod map_token_pairs;
+
+#[path = "4_store_token_pairs.rs"]
+mod store_token_pairs;
+
+#[path = "5_map_protocol_changes.rs"]
+mod map_protocol_changes;
+
+mod config;
+mod helper_funcs;

--- a/substreams/ethereum-peapods/src/modules/modules.rs
+++ b/substreams/ethereum-peapods/src/modules/modules.rs
@@ -1,0 +1,143 @@
+use crate::abi;
+use anyhow::Result;
+use substreams::store::{StoreGet, StoreGetBigInt, StoreNew, StoreSet, StoreSetProto};
+use substreams_ethereum::{
+    pb::eth::{self},
+    Function,
+};
+use tycho_substreams::prelude::*;
+
+// #[substreams::handlers::map]
+// pub fn map_adapter_static(
+//     params: String, // adapter address (hex)
+//     _block: eth::v2::Block,
+// ) -> Result<BlockTransactionProtocolComponents, anyhow::Error> {
+//     // Decode the adapter address from the input parameter.
+//     let adapter_address = hex::decode(params).unwrap();
+
+//     // static ProtocolComponent for the adapter.
+//     let adapter_component = ProtocolComponent::at_contract(&adapter_address)
+//         .with_attributes(&[("role", "adapter"), ("function", "ERC-7815 Adapter")]);
+
+//     // Since the adapter is static, if there will be multiple deployments then tx can be included
+//     let tx_component =
+//         TransactionProtocolComponents { tx: None, components: vec![adapter_component] };
+
+//     Ok(BlockTransactionProtocolComponents { tx_components: vec![tx_component] })
+// }
+
+// This mapping module processes each block, filters for function calls
+// to the adapter, and emits ProtocolComponents accordingly.
+#[substreams::handlers::map]
+pub fn map_protocol_components(
+    params: String, // adapter address in hex form
+    block: eth::v2::Block,
+) -> Result<BlockTransactionProtocolComponents, anyhow::Error> {
+    // Decode adapter address from parameters.
+    let adapter_address = hex::decode(params).unwrap();
+
+    let mut tx_components = vec![];
+
+    for tx in block.transactions() {
+        // Iterate over the internal calls in the transaction.
+        let components: Vec<ProtocolComponent> = tx
+            .calls()
+            // Filter calls directed to our adapter contract.
+            .filter(|call| call.transaction.to == adapter_address)
+            .filter(|call| !call.call.state_reverted)
+            .filter_map(|call| {
+                // Depending on the function selector, identify the call type.
+                if is_swap_call(&call.call) {
+                    let swap_call = abi::swap_adapter::functions::Swap2::match_and_decode(call)?;
+
+                    let (addr1, addr2) =
+                        canonicalize_addresses(swap_call.sell_token, swap_call.buy_token);
+
+                    Some(ProtocolComponent {
+                        id: key_from_tokens(addr1.clone(), addr2.clone()),
+                        tokens: vec![addr1, addr2],
+                        contracts: vec![],
+                        static_att: vec![],
+                        protocol_type: Some(ProtocolType {
+                            name: "adapter_pool".to_string(),
+                            financial_type: FinancialType::Swap.into(),
+                            attribute_schema: vec![],
+                            implementation_type: ImplementationType::Vm.into(),
+                        }),
+                        change: ChangeType::Creation.into(),
+                    })
+                } else if is_swap_to_price_call(&call.call) {
+                    let swap_to_price_call =
+                        abi::swap_adapter::functions::SwapToPrice::match_and_decode(call)?;
+
+                    let (addr1, addr2) = canonicalize_addresses(
+                        swap_to_price_call.sell_token,
+                        swap_to_price_call.buy_token,
+                    );
+
+                    Some(ProtocolComponent {
+                        id: key_from_tokens(addr1.clone(), addr2.clone()),
+                        tokens: vec![addr1, addr2],
+                        contracts: vec![],
+                        static_att: vec![],
+                        protocol_type: Some(ProtocolType {
+                            name: "adapter_pool".to_string(),
+                            financial_type: FinancialType::Swap.into(),
+                            attribute_schema: vec![],
+                            implementation_type: ImplementationType::Vm.into(),
+                        }),
+                        change: ChangeType::Creation.into(),
+                    })
+                } else if is_price_call(&call.call) {
+                    let price_call = abi::swap_adapter::functions::Price::match_and_decode(call)?;
+
+                    let (addr1, addr2) =
+                        canonicalize_addresses(price_call.sell_token, price_call.buy_token);
+
+                    Some(ProtocolComponent {
+                        id: key_from_tokens(addr1.clone(), addr2.clone()),
+                        tokens: vec![addr1, addr2],
+                        contracts: vec![],
+                        static_att: vec![],
+                        protocol_type: Some(ProtocolType {
+                            name: "adapter_pool".to_string(),
+                            financial_type: FinancialType::Swap.into(),
+                            attribute_schema: vec![],
+                            implementation_type: ImplementationType::Vm.into(),
+                        }),
+                        change: ChangeType::Creation.into(),
+                    })
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        if !components.is_empty() {
+            tx_components.push(TransactionProtocolComponents { tx: Some(tx.into()), components });
+        }
+    }
+
+    Ok(BlockTransactionProtocolComponents { tx_components })
+}
+
+#[substreams::handlers::store]
+pub fn store_adapter_token_pairs(
+    components: BlockTransactionProtocolComponents,
+    component_store: StoreSetProto<ProtocolComponent>,
+) {
+    for tx_component in components.tx_components {
+        for component in tx_component.components {
+            component_store.set(0, &component.id, &component);
+        }
+    }
+}
+
+#[substreams::handlers::map]
+pub fn map_adapter_token_delta(
+    params: String,
+    block: eth::v2::Block,
+    _store: StoreGetBigInt,
+) -> Result<BlockBalanceDeltas> {
+    Ok(BlockBalanceDeltas { balance_deltas: vec![] })
+}

--- a/substreams/ethereum-peapods/src/pb/adapter.v1.rs
+++ b/substreams/ethereum-peapods/src/pb/adapter.v1.rs
@@ -1,0 +1,114 @@
+// @generated
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Trade {
+    #[prost(string, tag="1")]
+    pub calculated_amount: ::prost::alloc::string::String,
+    #[prost(string, tag="2")]
+    pub gas_used: ::prost::alloc::string::String,
+    #[prost(string, tag="3")]
+    pub marginal_price_after_trade: ::prost::alloc::string::String,
+}
+/// A struct describing a transaction.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Transaction {
+    /// The transaction hash.
+    #[prost(bytes="vec", tag="1")]
+    pub hash: ::prost::alloc::vec::Vec<u8>,
+    /// The sender of the transaction.
+    #[prost(bytes="vec", tag="2")]
+    pub from: ::prost::alloc::vec::Vec<u8>,
+    /// The receiver of the transaction.
+    #[prost(bytes="vec", tag="3")]
+    pub to: ::prost::alloc::vec::Vec<u8>,
+    /// The transactions index within the block.
+    #[prost(uint32, tag="4")]
+    pub index: u32,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FunctionCall {
+    #[prost(string, tag="1")]
+    pub id: ::prost::alloc::string::String,
+    #[prost(string, tag="2")]
+    pub sell_token: ::prost::alloc::string::String,
+    #[prost(string, tag="3")]
+    pub buy_token: ::prost::alloc::string::String,
+    #[prost(message, optional, tag="4")]
+    pub transaction: ::core::option::Option<Transaction>,
+    #[prost(oneof="function_call::CallType", tags="5, 6, 7")]
+    pub call_type: ::core::option::Option<function_call::CallType>,
+}
+/// Nested message and enum types in `FunctionCall`.
+pub mod function_call {
+    #[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum CallType {
+        #[prost(message, tag="5")]
+        Swap(super::SwapCallData),
+        #[prost(message, tag="6")]
+        Price(super::PriceCallData),
+        #[prost(message, tag="7")]
+        SwapToPrice(super::SwapToPriceCallData),
+    }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SwapCallData {
+    #[prost(enumeration="OrderSide", tag="1")]
+    pub side: i32,
+    #[prost(uint64, tag="2")]
+    pub specified_amount: u64,
+    #[prost(message, optional, tag="3")]
+    pub result: ::core::option::Option<Trade>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PriceCallData {
+    #[prost(bytes="vec", repeated, tag="1")]
+    pub specified_amounts: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
+    #[prost(string, repeated, tag="2")]
+    pub prices: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SwapToPriceCallData {
+    #[prost(string, tag="1")]
+    pub limit_price: ::prost::alloc::string::String,
+    #[prost(message, optional, tag="2")]
+    pub result: ::core::option::Option<Trade>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FunctionCalls {
+    #[prost(message, repeated, tag="1")]
+    pub calls: ::prost::alloc::vec::Vec<FunctionCall>,
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum OrderSide {
+    Sell = 0,
+    Buy = 1,
+}
+impl OrderSide {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            OrderSide::Sell => "SELL",
+            OrderSide::Buy => "BUY",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "SELL" => Some(Self::Sell),
+            "BUY" => Some(Self::Buy),
+            _ => None,
+        }
+    }
+}
+// @@protoc_insertion_point(module)

--- a/substreams/ethereum-peapods/src/pb/mod.rs
+++ b/substreams/ethereum-peapods/src/pb/mod.rs
@@ -1,0 +1,17 @@
+// @generated
+pub mod adapter {
+    // @@protoc_insertion_point(attribute:adapter.v1)
+    pub mod v1 {
+        include!("adapter.v1.rs");
+        // @@protoc_insertion_point(adapter.v1)
+    }
+}
+pub mod tycho {
+    pub mod evm {
+        // @@protoc_insertion_point(attribute:tycho.evm.v1)
+        pub mod v1 {
+            include!("tycho.evm.v1.rs");
+            // @@protoc_insertion_point(tycho.evm.v1)
+        }
+    }
+}

--- a/substreams/ethereum-peapods/src/pb/tycho.evm.v1.rs
+++ b/substreams/ethereum-peapods/src/pb/tycho.evm.v1.rs
@@ -1,0 +1,382 @@
+// @generated
+// This file contains the proto definitions for Substreams common to all integrations.
+
+/// A struct describing a block.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Block {
+    /// The blocks hash.
+    #[prost(bytes="vec", tag="1")]
+    pub hash: ::prost::alloc::vec::Vec<u8>,
+    /// The parent blocks hash.
+    #[prost(bytes="vec", tag="2")]
+    pub parent_hash: ::prost::alloc::vec::Vec<u8>,
+    /// The block number.
+    #[prost(uint64, tag="3")]
+    pub number: u64,
+    /// The block timestamp.
+    #[prost(uint64, tag="4")]
+    pub ts: u64,
+}
+/// A struct describing a transaction.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Transaction {
+    /// The transaction hash.
+    #[prost(bytes="vec", tag="1")]
+    pub hash: ::prost::alloc::vec::Vec<u8>,
+    /// The sender of the transaction.
+    #[prost(bytes="vec", tag="2")]
+    pub from: ::prost::alloc::vec::Vec<u8>,
+    /// The receiver of the transaction.
+    #[prost(bytes="vec", tag="3")]
+    pub to: ::prost::alloc::vec::Vec<u8>,
+    /// The transactions index within the block.
+    /// TODO: should this be uint32? to match the type from the native substream type?
+    #[prost(uint64, tag="4")]
+    pub index: u64,
+}
+/// A custom struct representing an arbitrary attribute of a protocol component.
+/// This is mainly used by the native integration to track the necessary information about the protocol.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Attribute {
+    /// The name of the attribute.
+    #[prost(string, tag="1")]
+    pub name: ::prost::alloc::string::String,
+    /// The value of the attribute.
+    #[prost(bytes="vec", tag="2")]
+    pub value: ::prost::alloc::vec::Vec<u8>,
+    /// The type of change the attribute underwent.
+    #[prost(enumeration="ChangeType", tag="3")]
+    pub change: i32,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ProtocolType {
+    #[prost(string, tag="1")]
+    pub name: ::prost::alloc::string::String,
+    #[prost(enumeration="FinancialType", tag="2")]
+    pub financial_type: i32,
+    #[prost(message, repeated, tag="3")]
+    pub attribute_schema: ::prost::alloc::vec::Vec<Attribute>,
+    #[prost(enumeration="ImplementationType", tag="4")]
+    pub implementation_type: i32,
+}
+/// A struct describing a part of the protocol.
+/// Note: For example this can be a UniswapV2 pair, that tracks the two ERC20 tokens used by the pair, 
+/// the component would represent a single contract. In case of VM integration, such component would 
+/// not need any attributes, because all the relevant info would be tracked via storage slots and balance changes.
+/// It can also be a wrapping contract, like WETH, that has a constant price, but it allows swapping tokens. 
+/// This is why the name ProtocolComponent is used instead of "Pool" or "Pair".
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ProtocolComponent {
+    /// A unique identifier for the component within the protocol.
+    /// Can be e.g. a stringified address or a string describing the trading pair.
+    #[prost(string, tag="1")]
+    pub id: ::prost::alloc::string::String,
+    /// Addresses of the ERC20 tokens used by the component.
+    #[prost(bytes="vec", repeated, tag="2")]
+    pub tokens: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
+    /// Addresses of the contracts used by the component.
+    /// Usually it is a single contract, but some protocols use multiple contracts.
+    #[prost(bytes="vec", repeated, tag="3")]
+    pub contracts: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
+    /// Static attributes of the component.
+    /// These attributes MUST be immutable. If it can ever change, it should be given as an EntityChanges for this component id.
+    /// The inner ChangeType of the attribute has to match the ChangeType of the ProtocolComponent.
+    #[prost(message, repeated, tag="4")]
+    pub static_att: ::prost::alloc::vec::Vec<Attribute>,
+    /// Type of change the component underwent.
+    #[prost(enumeration="ChangeType", tag="5")]
+    pub change: i32,
+    /// / Represents the functionality of the component.
+    #[prost(message, optional, tag="6")]
+    pub protocol_type: ::core::option::Option<ProtocolType>,
+}
+/// A struct for following the changes of Total Value Locked (TVL) of a protocol component.
+/// Note that if a ProtocolComponent contains multiple contracts, the TVL is tracked for the component as a whole.
+/// E.g. for UniswapV2 pair WETH/USDC, this tracks the USDC and WETH balance of the pair contract.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct BalanceChange {
+    /// The address of the ERC20 token whose balance changed.
+    #[prost(bytes="vec", tag="1")]
+    pub token: ::prost::alloc::vec::Vec<u8>,
+    /// The new balance of the token. Note: it must be a big endian encoded int.
+    #[prost(bytes="vec", tag="2")]
+    pub balance: ::prost::alloc::vec::Vec<u8>,
+    /// The id of the component whose TVL is tracked.  Note: This MUST be utf8 encoded.
+    /// If the protocol component includes multiple contracts, the balance change must be aggregated to reflect how much tokens can be traded.
+    #[prost(bytes="vec", tag="3")]
+    pub component_id: ::prost::alloc::vec::Vec<u8>,
+}
+// Native entities
+
+/// A component is a set of attributes that are associated with a custom entity.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct EntityChanges {
+    /// A unique identifier of the entity within the protocol.
+    #[prost(string, tag="1")]
+    pub component_id: ::prost::alloc::string::String,
+    /// The set of attributes that are associated with the entity.
+    #[prost(message, repeated, tag="2")]
+    pub attributes: ::prost::alloc::vec::Vec<Attribute>,
+}
+// VM entities
+
+/// A key value entry into contract storage.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ContractSlot {
+    /// A contract's storage slot.
+    #[prost(bytes="vec", tag="2")]
+    pub slot: ::prost::alloc::vec::Vec<u8>,
+    /// The new value for this storage slot.
+    #[prost(bytes="vec", tag="3")]
+    pub value: ::prost::alloc::vec::Vec<u8>,
+}
+/// A struct for following the token balance changes for a contract.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AccountBalanceChange {
+    /// The address of the ERC20 token whose balance changed.
+    #[prost(bytes="vec", tag="1")]
+    pub token: ::prost::alloc::vec::Vec<u8>,
+    /// The new balance of the token. Note: it must be a big endian encoded int.
+    #[prost(bytes="vec", tag="2")]
+    pub balance: ::prost::alloc::vec::Vec<u8>,
+}
+/// Changes made to a single contract's state.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ContractChange {
+    /// The contract's address
+    #[prost(bytes="vec", tag="1")]
+    pub address: ::prost::alloc::vec::Vec<u8>,
+    /// The new balance of the contract, empty bytes indicates no change.
+    #[prost(bytes="vec", tag="2")]
+    pub balance: ::prost::alloc::vec::Vec<u8>,
+    /// The new code of the contract, empty bytes indicates no change.
+    #[prost(bytes="vec", tag="3")]
+    pub code: ::prost::alloc::vec::Vec<u8>,
+    /// The changes to this contract's slots, empty sequence indicates no change.
+    #[prost(message, repeated, tag="4")]
+    pub slots: ::prost::alloc::vec::Vec<ContractSlot>,
+    /// Whether this is an update, a creation or a deletion.
+    #[prost(enumeration="ChangeType", tag="5")]
+    pub change: i32,
+    /// The new ERC20 balances of the contract.
+    #[prost(message, repeated, tag="6")]
+    pub token_balances: ::prost::alloc::vec::Vec<AccountBalanceChange>,
+}
+// Aggregate entities
+
+/// A set of changes aggregated by transaction.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TransactionChanges {
+    /// The transaction instance that results in the changes.
+    #[prost(message, optional, tag="1")]
+    pub tx: ::core::option::Option<Transaction>,
+    /// Contains the changes induced by the above transaction, aggregated on a per-contract basis.
+    /// Contains the contract changes induced by the above transaction, usually for tracking VM components.
+    #[prost(message, repeated, tag="2")]
+    pub contract_changes: ::prost::alloc::vec::Vec<ContractChange>,
+    /// Contains the entity changes induced by the above transaction.
+    /// Usually for tracking native components or used for VM extensions (plugins).
+    #[prost(message, repeated, tag="3")]
+    pub entity_changes: ::prost::alloc::vec::Vec<EntityChanges>,
+    /// An array of newly added components.
+    #[prost(message, repeated, tag="4")]
+    pub component_changes: ::prost::alloc::vec::Vec<ProtocolComponent>,
+    /// An array of balance changes to components.
+    #[prost(message, repeated, tag="5")]
+    pub balance_changes: ::prost::alloc::vec::Vec<BalanceChange>,
+}
+/// A set of transaction changes within a single block.
+/// This message must be the output of your substreams module.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct BlockChanges {
+    /// The block for which these changes are collectively computed.
+    #[prost(message, optional, tag="1")]
+    pub block: ::core::option::Option<Block>,
+    /// The set of transaction changes observed in the specified block.
+    #[prost(message, repeated, tag="2")]
+    pub changes: ::prost::alloc::vec::Vec<TransactionChanges>,
+}
+/// Enum to specify the type of a change.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum ChangeType {
+    Unspecified = 0,
+    Update = 1,
+    Creation = 2,
+    Deletion = 3,
+}
+impl ChangeType {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            ChangeType::Unspecified => "CHANGE_TYPE_UNSPECIFIED",
+            ChangeType::Update => "CHANGE_TYPE_UPDATE",
+            ChangeType::Creation => "CHANGE_TYPE_CREATION",
+            ChangeType::Deletion => "CHANGE_TYPE_DELETION",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "CHANGE_TYPE_UNSPECIFIED" => Some(Self::Unspecified),
+            "CHANGE_TYPE_UPDATE" => Some(Self::Update),
+            "CHANGE_TYPE_CREATION" => Some(Self::Creation),
+            "CHANGE_TYPE_DELETION" => Some(Self::Deletion),
+            _ => None,
+        }
+    }
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum FinancialType {
+    Swap = 0,
+    Lend = 1,
+    Leverage = 2,
+    Psm = 3,
+}
+impl FinancialType {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            FinancialType::Swap => "SWAP",
+            FinancialType::Lend => "LEND",
+            FinancialType::Leverage => "LEVERAGE",
+            FinancialType::Psm => "PSM",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "SWAP" => Some(Self::Swap),
+            "LEND" => Some(Self::Lend),
+            "LEVERAGE" => Some(Self::Leverage),
+            "PSM" => Some(Self::Psm),
+            _ => None,
+        }
+    }
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum ImplementationType {
+    Vm = 0,
+    Custom = 1,
+}
+impl ImplementationType {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            ImplementationType::Vm => "VM",
+            ImplementationType::Custom => "CUSTOM",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "VM" => Some(Self::Vm),
+            "CUSTOM" => Some(Self::Custom),
+            _ => None,
+        }
+    }
+}
+// WARNING: DEPRECATED. Please use common.proto's TransactionChanges and BlockChanges instead.
+// This file contains proto definitions specific to the VM integration.
+
+/// A set of changes aggregated by transaction.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TransactionContractChanges {
+    /// The transaction instance that results in the changes.
+    #[prost(message, optional, tag="1")]
+    pub tx: ::core::option::Option<Transaction>,
+    /// Contains the changes induced by the above transaction, aggregated on a per-contract basis.
+    #[prost(message, repeated, tag="2")]
+    pub contract_changes: ::prost::alloc::vec::Vec<ContractChange>,
+    /// An array of newly added components.
+    #[prost(message, repeated, tag="3")]
+    pub component_changes: ::prost::alloc::vec::Vec<ProtocolComponent>,
+    /// An array of balance changes to components.
+    #[prost(message, repeated, tag="4")]
+    pub balance_changes: ::prost::alloc::vec::Vec<BalanceChange>,
+}
+/// A set of transaction changes within a single block.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct BlockContractChanges {
+    /// The block for which these changes are collectively computed.
+    #[prost(message, optional, tag="1")]
+    pub block: ::core::option::Option<Block>,
+    /// The set of transaction changes observed in the specified block.
+    #[prost(message, repeated, tag="2")]
+    pub changes: ::prost::alloc::vec::Vec<TransactionContractChanges>,
+}
+/// A message containing relative balance changes.
+///
+/// Used to track token balances of protocol components in case they are only
+/// available as relative values within a block.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct BalanceDelta {
+    /// The ordinal of the balance change. Must be unique & deterministic over all balances
+    /// changes within a block.
+    #[prost(uint64, tag="1")]
+    pub ord: u64,
+    /// The tx hash of the transaction that caused the balance change.
+    #[prost(message, optional, tag="2")]
+    pub tx: ::core::option::Option<Transaction>,
+    /// The address of the ERC20 token whose balance changed.
+    #[prost(bytes="vec", tag="3")]
+    pub token: ::prost::alloc::vec::Vec<u8>,
+    /// The delta balance of the token.
+    #[prost(bytes="vec", tag="4")]
+    pub delta: ::prost::alloc::vec::Vec<u8>,
+    /// The id of the component whose TVL is tracked.
+    /// If the protocol component includes multiple contracts, the balance change must be
+    /// aggregated to reflect how much tokens can be traded.
+    #[prost(bytes="vec", tag="5")]
+    pub component_id: ::prost::alloc::vec::Vec<u8>,
+}
+/// A set of balances deltas, usually a group of changes within a single block.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct BlockBalanceDeltas {
+    #[prost(message, repeated, tag="1")]
+    pub balance_deltas: ::prost::alloc::vec::Vec<BalanceDelta>,
+}
+/// A message containing protocol components that were created by a single tx.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TransactionProtocolComponents {
+    #[prost(message, optional, tag="1")]
+    pub tx: ::core::option::Option<Transaction>,
+    #[prost(message, repeated, tag="2")]
+    pub components: ::prost::alloc::vec::Vec<ProtocolComponent>,
+}
+/// All protocol components that were created within a block with their corresponding tx.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct BlockTransactionProtocolComponents {
+    #[prost(message, repeated, tag="1")]
+    pub tx_components: ::prost::alloc::vec::Vec<TransactionProtocolComponents>,
+}
+// @@protoc_insertion_point(module)

--- a/substreams/ethereum-peapods/substreams-legacy.yaml
+++ b/substreams/ethereum-peapods/substreams-legacy.yaml
@@ -1,0 +1,84 @@
+specVersion: v0.1.0
+package:
+    name: "ethereum_peapods"
+    version: v0.1.0
+
+protobuf:
+    files:
+        - tycho/evm/v1/vm.proto
+        - tycho/evm/v1/common.proto
+        - tycho/evm/v1/utils.proto
+        - adapter.proto
+    importPaths:
+        - ./proto/v1
+        - ../../proto
+
+binaries:
+    default:
+        type: wasm/rust-v1
+        file: ../target/wasm32-unknown-unknown/release/ethereum_peapods.wasm
+
+network: base
+networks:
+    base:
+        initialBlock:
+            map_function_calls: 26505334
+            store_exchange_price: 26505334
+            map_token_pairs: 26505334
+            store_token_pairs: 26505334
+            map_protocol_changes: 26505334
+        params:
+            map_function_calls: "adapter_address=010859942F136CB44fb7C057e0F2FEe50baf3008"
+            map_token_pairs: "adapter_address=010859942F136CB44fb7C057e0F2FEe50baf3008"
+
+params:
+    map_function_calls: "adapter_address=010859942F136CB44fb7C057e0F2FEe50baf3008"
+    map_token_pairs: "adapter_address=010859942F136CB44fb7C057e0F2FEe50baf3008"
+
+modules:
+    - name: map_function_calls
+      kind: map
+      initialBlock: 26505334
+      inputs:
+          - params: string
+          - source: sf.ethereum.type.v2.Block
+      output:
+          type: proto:adapter.v1.FunctionCalls
+
+    - name: store_exchange_price
+      kind: store
+      initialBlock: 26505334
+      updatePolicy: set
+      valueType: proto:adapter.v1.Fraction
+      inputs:
+          - map: map_function_calls
+
+    - name: map_token_pairs
+      kind: map
+      initialBlock: 26505334
+      inputs:
+          - params: string
+          - source: sf.ethereum.type.v2.Block
+      output:
+          type: proto:tycho.evm.v1.BlockTransactionProtocolComponents
+
+    - name: store_token_pairs
+      kind: store
+      initialBlock: 26505334
+      updatePolicy: set
+      valueType: proto:tycho.evm.v1.ProtocolComponent
+      inputs:
+          - map: map_token_pairs
+
+    - name: map_protocol_changes
+      kind: map
+      initialBlock: 26505334
+      inputs:
+          - source: sf.ethereum.type.v2.Block
+          - map: map_function_calls
+          - map: map_token_pairs
+          - store: store_exchange_price
+            mode: deltas
+      output:
+          type: proto:tycho.evm.v1.BlockChanges
+

--- a/substreams/ethereum-peapods/substreams-new.yaml
+++ b/substreams/ethereum-peapods/substreams-new.yaml
@@ -1,0 +1,84 @@
+specVersion: v0.1.0
+package:
+    name: "ethereum_peapods"
+    version: v0.1.0
+
+protobuf:
+    files:
+        - tycho/evm/v1/vm.proto
+        - tycho/evm/v1/common.proto
+        - tycho/evm/v1/utils.proto
+        - adapter.proto
+    importPaths:
+        - ./proto/v1
+        - ../../proto
+
+binaries:
+    default:
+        type: wasm/rust-v1
+        file: ../target/wasm32-unknown-unknown/release/ethereum_peapods.wasm
+
+network: base
+networks:
+    base:
+        initialBlock:
+            map_function_calls: 26505480
+            store_exchange_price: 26505480
+            map_token_pairs: 26505480
+            store_token_pairs: 26505480
+            map_protocol_changes: 26505480
+        params:
+            map_function_calls: "adapter_address=b42807182b64e80C72B154EF6E2997ecf8084eD8"
+            map_token_pairs: "adapter_address=b42807182b64e80C72B154EF6E2997ecf8084eD8"
+
+params:
+    map_function_calls: "adapter_address=b42807182b64e80C72B154EF6E2997ecf8084eD8"
+    map_token_pairs: "adapter_address=b42807182b64e80C72B154EF6E2997ecf8084eD8"
+
+modules:
+    - name: map_function_calls
+      kind: map
+      initialBlock: 26505480
+      inputs:
+          - params: string
+          - source: sf.ethereum.type.v2.Block
+      output:
+          type: proto:adapter.v1.FunctionCalls
+
+    - name: store_exchange_price
+      kind: store
+      initialBlock: 26505480
+      updatePolicy: set
+      valueType: proto:adapter.v1.Fraction
+      inputs:
+          - map: map_function_calls
+
+    - name: map_token_pairs
+      kind: map
+      initialBlock: 26505480
+      inputs:
+          - params: string
+          - source: sf.ethereum.type.v2.Block
+      output:
+          type: proto:tycho.evm.v1.BlockTransactionProtocolComponents
+
+    - name: store_token_pairs
+      kind: store
+      initialBlock: 26505480
+      updatePolicy: set
+      valueType: proto:tycho.evm.v1.ProtocolComponent
+      inputs:
+          - map: map_token_pairs
+
+    - name: map_protocol_changes
+      kind: map
+      initialBlock: 26505480
+      inputs:
+          - source: sf.ethereum.type.v2.Block
+          - map: map_function_calls
+          - map: map_token_pairs
+          - store: store_exchange_price
+            mode: deltas
+      output:
+          type: proto:tycho.evm.v1.BlockChanges
+


### PR DESCRIPTION
# Peapods Swap Adapter Substreams Package
This PR integrates the swap adapter for peapods into tycho protocol's sdk. Following is the package overview - 

## Package Overview

The package consists of five core modules that work together to track and index protocol changes:

1. `map_function_calls` - Maps adapter contract function calls (Swap, SwapToPrice, Price) into structured FunctionCalls
2. `store_exchange_price` - Stores exchange prices from function calls in the store
3. `map_token_pairs` - Creates protocol components for token pairs based on function calls
4. `store_token_pairs` - Persists token pair protocol components in the store
5. `map_protocol_changes` - Aggregates changes from function calls and components into BlockChanges

## Config Overview
Currently there are 2 config `substreams.yaml` files for the base network - 

- `substreams-legacy.yaml` - This config file is for the legacy swap adapter contract that helps indexing it on base.
- `substreams-new.yaml` - This config file is for the new swap adapter contract implementation that helps indexing it on base.

> The detailed overview of the package is also present in the `README.md` file.