### PR TITLE
refactor: remove unnecessary clones for UniswapV3 Substreams

### DIFF
--- a/substreams/Cargo.lock
+++ b/substreams/Cargo.lock
@@ -384,7 +384,7 @@ dependencies = [
 
 [[package]]
 name = "ethereum-uniswap-v3-logs-only"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "ethabi 18.0.0",

--- a/substreams/ethereum-uniswap-v3-logs-only/Cargo.toml
+++ b/substreams/ethereum-uniswap-v3-logs-only/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum-uniswap-v3-logs-only"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [lib]

--- a/substreams/ethereum-uniswap-v3-logs-only/base-uniswap-v3.yaml
+++ b/substreams/ethereum-uniswap-v3-logs-only/base-uniswap-v3.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: "base_uniswap_v3_logs_only"
-  version: v0.1.0
+  version: v0.1.1
 
 protobuf:
   files:

--- a/substreams/ethereum-uniswap-v3-logs-only/ethereum-uniswap-v3.yaml
+++ b/substreams/ethereum-uniswap-v3-logs-only/ethereum-uniswap-v3.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: "ethereum_uniswap_v3_logs_only"
-  version: v0.1.0
+  version: v0.1.1
 
 protobuf:
   files:

--- a/substreams/ethereum-uniswap-v3-logs-only/src/modules/4_map_and_store_balance_changes.rs
+++ b/substreams/ethereum-uniswap-v3-logs-only/src/modules/4_map_and_store_balance_changes.rs
@@ -35,7 +35,7 @@ fn event_to_balance_deltas(event: PoolEvent) -> Vec<BalanceDelta> {
     match event.r#type.unwrap() {
         pool_event::Type::Mint(e) => vec![
             BalanceDelta {
-                token: hex::decode(event.token0.clone()).unwrap(),
+                token: hex::decode(event.token0).unwrap(),
                 delta: BigInt::from_str(&e.amount_0)
                     .unwrap()
                     .to_signed_bytes_be(),
@@ -43,11 +43,11 @@ fn event_to_balance_deltas(event: PoolEvent) -> Vec<BalanceDelta> {
                 ord: event.log_ordinal,
                 tx: event
                     .transaction
-                    .clone()
+                    .as_ref()
                     .map(Into::into),
             },
             BalanceDelta {
-                token: hex::decode(event.token1.clone()).unwrap(),
+                token: hex::decode(event.token1).unwrap(),
                 delta: BigInt::from_str(&e.amount_1)
                     .unwrap()
                     .to_signed_bytes_be(),
@@ -58,7 +58,7 @@ fn event_to_balance_deltas(event: PoolEvent) -> Vec<BalanceDelta> {
         ],
         pool_event::Type::Collect(e) => vec![
             BalanceDelta {
-                token: hex::decode(event.token0.clone()).unwrap(),
+                token: hex::decode(event.token0).unwrap(),
                 delta: BigInt::from_str(&e.amount_0)
                     .unwrap()
                     .neg()
@@ -67,11 +67,11 @@ fn event_to_balance_deltas(event: PoolEvent) -> Vec<BalanceDelta> {
                 ord: event.log_ordinal,
                 tx: event
                     .transaction
-                    .clone()
+                    .as_ref()
                     .map(Into::into),
             },
             BalanceDelta {
-                token: hex::decode(event.token1.clone()).unwrap(),
+                token: hex::decode(event.token1).unwrap(),
                 delta: BigInt::from_str(&e.amount_1)
                     .unwrap()
                     .neg()
@@ -86,7 +86,7 @@ fn event_to_balance_deltas(event: PoolEvent) -> Vec<BalanceDelta> {
         pool_event::Type::Swap(e) => {
             vec![
                 BalanceDelta {
-                    token: hex::decode(event.token0.clone()).unwrap(),
+                    token: hex::decode(event.token0).unwrap(),
                     delta: BigInt::from_str(&e.amount_0)
                         .unwrap()
                         .to_signed_bytes_be(),
@@ -94,15 +94,15 @@ fn event_to_balance_deltas(event: PoolEvent) -> Vec<BalanceDelta> {
                     ord: event.log_ordinal,
                     tx: event
                         .transaction
-                        .clone()
+                        .as_ref()
                         .map(Into::into),
                 },
                 BalanceDelta {
-                    token: hex::decode(event.token1.clone()).unwrap(),
+                    token: hex::decode(event.token1).unwrap(),
                     delta: BigInt::from_str(&e.amount_1)
                         .unwrap()
                         .to_signed_bytes_be(),
-                    component_id: address.clone(),
+                    component_id: address,
                     ord: event.log_ordinal,
                     tx: event.transaction.map(Into::into),
                 },
@@ -113,20 +113,18 @@ fn event_to_balance_deltas(event: PoolEvent) -> Vec<BalanceDelta> {
                 token: hex::decode(event.token0).unwrap(),
                 delta: BigInt::from_str(&e.paid_0)
                     .unwrap()
-                    .clone()
                     .to_signed_bytes_be(),
                 component_id: address.clone(),
                 ord: event.log_ordinal,
                 tx: event
                     .transaction
-                    .clone()
+                    .as_ref()
                     .map(Into::into),
             },
             BalanceDelta {
                 token: hex::decode(event.token1).unwrap(),
                 delta: BigInt::from_str(&e.paid_1)
                     .unwrap()
-                    .clone()
                     .to_signed_bytes_be(),
                 component_id: address,
                 ord: event.log_ordinal,
@@ -140,31 +138,21 @@ fn event_to_balance_deltas(event: PoolEvent) -> Vec<BalanceDelta> {
                     delta: BigInt::from_str(&e.amount_0)
                         .unwrap()
                         .neg()
-                        .clone()
                         .to_signed_bytes_be(),
-                    component_id: event
-                        .pool_address
-                        .clone()
-                        .as_bytes()
-                        .to_vec(),
+                    component_id: address.clone(),
                     ord: event.log_ordinal,
                     tx: event
                         .transaction
-                        .clone()
+                        .as_ref()
                         .map(Into::into),
                 },
                 BalanceDelta {
                     token: hex::decode(event.token1).unwrap(),
                     delta: BigInt::from_str(&e.amount_1)
                         .unwrap()
-                        .clone()
                         .neg()
                         .to_signed_bytes_be(),
-                    component_id: event
-                        .pool_address
-                        .clone()
-                        .as_bytes()
-                        .to_vec(),
+                    component_id: address,
                     ord: event.log_ordinal,
                     tx: event.transaction.map(Into::into),
                 },

--- a/substreams/ethereum-uniswap-v3-logs-only/src/modules/4_map_and_store_ticks.rs
+++ b/substreams/ethereum-uniswap-v3-logs-only/src/modules/4_map_and_store_ticks.rs
@@ -27,7 +27,7 @@ pub fn map_ticks_changes(events: Events) -> Result<TickDeltas, anyhow::Error> {
 
 #[substreams::handlers::store]
 pub fn store_ticks_liquidity(ticks_deltas: TickDeltas, store: StoreAddBigInt) {
-    let mut deltas = ticks_deltas.deltas.clone();
+    let mut deltas = ticks_deltas.deltas;
 
     deltas.sort_unstable_by_key(|delta| delta.ordinal);
 

--- a/substreams/ethereum-uniswap-v3-logs-only/src/modules/5_map_protocol_changes.rs
+++ b/substreams/ethereum-uniswap-v3-logs-only/src/modules/5_map_protocol_changes.rs
@@ -170,10 +170,10 @@ fn event_to_attributes_updates(event: PoolEvent) -> Vec<(Transaction, PoolAddres
                 (
                     event
                         .transaction
-                        .clone()
+                        .as_ref()
                         .unwrap()
                         .into(),
-                    hex::decode(event.pool_address.clone()).unwrap(),
+                    hex::decode(&event.pool_address).unwrap(),
                     Attribute {
                         name: "sqrt_price_x96".to_string(),
                         value: BigInt::from_str(&initalize.sqrt_price)
@@ -197,10 +197,10 @@ fn event_to_attributes_updates(event: PoolEvent) -> Vec<(Transaction, PoolAddres
             (
                 event
                     .transaction
-                    .clone()
+                    .as_ref()
                     .unwrap()
                     .into(),
-                hex::decode(event.pool_address.clone()).unwrap(),
+                hex::decode(&event.pool_address).unwrap(),
                 Attribute {
                     name: "sqrt_price_x96".to_string(),
                     value: BigInt::from_str(&swap.sqrt_price)
@@ -223,10 +223,10 @@ fn event_to_attributes_updates(event: PoolEvent) -> Vec<(Transaction, PoolAddres
             (
                 event
                     .transaction
-                    .clone()
+                    .as_ref()
                     .unwrap()
                     .into(),
-                hex::decode(event.pool_address.clone()).unwrap(),
+                hex::decode(&event.pool_address).unwrap(),
                 Attribute {
                     name: "protocol_fees/token0".to_string(),
                     value: BigInt::from(sfp.fee_protocol_0_new).to_signed_bytes_be(),

--- a/substreams/ethereum-uniswap-v3-logs-only/src/modules/mod.rs
+++ b/substreams/ethereum-uniswap-v3-logs-only/src/modules/mod.rs
@@ -32,6 +32,28 @@ impl From<TransactionTrace> for Transaction {
     }
 }
 
+impl From<&TransactionTrace> for Transaction {
+    fn from(value: &TransactionTrace) -> Self {
+        Self {
+            hash: value.hash.clone(),
+            from: value.from.clone(),
+            to: value.to.clone(),
+            index: value.index.into(),
+        }
+    }
+}
+
+impl From<&Transaction> for tycho_substreams::prelude::Transaction {
+    fn from(value: &Transaction) -> Self {
+        Self {
+            hash: value.hash.clone(),
+            from: value.from.clone(),
+            to: value.to.clone(),
+            index: value.index,
+        }
+    }
+}
+
 impl From<Transaction> for tycho_substreams::prelude::Transaction {
     fn from(value: Transaction) -> Self {
         Self { hash: value.hash, from: value.from, to: value.to, index: value.index }


### PR DESCRIPTION
Also fixes a bug that would lead to emitting wrong balances if there is a `CollectProtocol` event triggered (currently not affecting because it's not enabled)