### PR TITLE
feat: extend DCI message structs

### DIFF
--- a/proto/tycho/evm/v1/common.proto
+++ b/proto/tycho/evm/v1/common.proto
@@ -167,7 +167,7 @@ message EntryPoint {
 message EntryPointParams {
   // The entrypoint id.
   string entrypoint_id = 1;
-  // [optional] The component that uses these entrypoint parameters.
+  // [optional] The component that uses these entrypoint parameters. Currently used for debugging purposes only.
   string component_id = 2;
   // The strategy and its corresponding data
   oneof trace_data {
@@ -178,10 +178,10 @@ message EntryPointParams {
 
 // RPC tracing strategy with its data
 message RPCTraceData {
-  // [optional] The caller to be used for the trace
+  // [optional] The caller to be used for the trace. If none is provided a chain default will be used.
   bytes caller = 1;
-  // The call_data to be used for the trace
-  bytes call_data = 2;
+  // The calldata to be used for the trace
+  bytes calldata = 2;
 }
 
 // A contract and associated storage changes

--- a/proto/tycho/evm/v1/common.proto
+++ b/proto/tycho/evm/v1/common.proto
@@ -159,6 +159,29 @@ message EntryPoint {
   bytes target = 2;
   // The signature of the function to analyse.
   string signature = 3;
+  // The id of the component that uses this entrypoint.
+  string component_id = 4;
+}
+
+// Parameters to trace the entrypoint
+message EntryPointParams {
+  // The entrypoint id.
+  string entrypoint_id = 1;
+  // [optional] The component that uses these entrypoint parameters.
+  string component_id = 2;
+  // The strategy and its corresponding data
+  oneof trace_data {
+    RPCTraceData rpc = 3;
+    // Add more strategies here
+  }
+}
+
+// RPC tracing strategy with its data
+message RPCTraceData {
+  // [optional] The caller to be used for the trace
+  bytes caller = 1;
+  // The call_data to be used for the trace
+  bytes call_data = 2;
 }
 
 // A contract and associated storage changes
@@ -187,6 +210,8 @@ message TransactionChanges {
   repeated BalanceChange balance_changes = 5;
   // An array of newly added entrypoints. Used for DCI enabled protocols.
   repeated EntryPoint entrypoints = 6;
+  // An array of entrypoint tracing parameteres. Used for DCI enabled protocols.
+  repeated EntryPointParams entrypoint_params = 7;
 }
 
 // A set of storage changes aggregated by transaction.

--- a/substreams/crates/tycho-substreams/src/models.rs
+++ b/substreams/crates/tycho-substreams/src/models.rs
@@ -184,6 +184,7 @@ impl TransactionChangesBuilder {
                 .entrypoints
                 .into_iter()
                 .collect::<Vec<_>>(),
+            entrypoint_params: Vec::new(), // TODO: Add entrypoint params to builder
         };
         if tx_changes.is_empty() {
             None

--- a/substreams/crates/tycho-substreams/src/pb/tycho.evm.v1.rs
+++ b/substreams/crates/tycho-substreams/src/pb/tycho.evm.v1.rs
@@ -200,7 +200,7 @@ pub struct EntryPointParams {
     /// The entrypoint id.
     #[prost(string, tag="1")]
     pub entrypoint_id: ::prost::alloc::string::String,
-    /// \[optional\] The component that uses these entrypoint parameters.
+    /// \[optional\] The component that uses these entrypoint parameters. Currently used for debugging purposes only.
     #[prost(string, tag="2")]
     pub component_id: ::prost::alloc::string::String,
     /// The strategy and its corresponding data
@@ -222,12 +222,12 @@ pub mod entry_point_params {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RpcTraceData {
-    /// \[optional\] The caller to be used for the trace
+    /// \[optional\] The caller to be used for the trace. If none is provided a chain default will be used.
     #[prost(bytes="vec", tag="1")]
     pub caller: ::prost::alloc::vec::Vec<u8>,
-    /// The call_data to be used for the trace
+    /// The calldata to be used for the trace
     #[prost(bytes="vec", tag="2")]
-    pub call_data: ::prost::alloc::vec::Vec<u8>,
+    pub calldata: ::prost::alloc::vec::Vec<u8>,
 }
 /// A contract and associated storage changes
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/substreams/crates/tycho-substreams/src/pb/tycho.evm.v1.rs
+++ b/substreams/crates/tycho-substreams/src/pb/tycho.evm.v1.rs
@@ -189,6 +189,45 @@ pub struct EntryPoint {
     /// The signature of the function to analyse.
     #[prost(string, tag="3")]
     pub signature: ::prost::alloc::string::String,
+    /// The id of the component that uses this entrypoint.
+    #[prost(string, tag="4")]
+    pub component_id: ::prost::alloc::string::String,
+}
+/// Parameters to trace the entrypoint
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct EntryPointParams {
+    /// The entrypoint id.
+    #[prost(string, tag="1")]
+    pub entrypoint_id: ::prost::alloc::string::String,
+    /// \[optional\] The component that uses these entrypoint parameters.
+    #[prost(string, tag="2")]
+    pub component_id: ::prost::alloc::string::String,
+    /// The strategy and its corresponding data
+    #[prost(oneof="entry_point_params::TraceData", tags="3")]
+    pub trace_data: ::core::option::Option<entry_point_params::TraceData>,
+}
+/// Nested message and enum types in `EntryPointParams`.
+pub mod entry_point_params {
+    /// The strategy and its corresponding data
+    #[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum TraceData {
+        /// Add more strategies here
+        #[prost(message, tag="3")]
+        Rpc(super::RpcTraceData),
+    }
+}
+/// RPC tracing strategy with its data
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RpcTraceData {
+    /// \[optional\] The caller to be used for the trace
+    #[prost(bytes="vec", tag="1")]
+    pub caller: ::prost::alloc::vec::Vec<u8>,
+    /// The call_data to be used for the trace
+    #[prost(bytes="vec", tag="2")]
+    pub call_data: ::prost::alloc::vec::Vec<u8>,
 }
 /// A contract and associated storage changes
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -227,6 +266,9 @@ pub struct TransactionChanges {
     /// An array of newly added entrypoints. Used for DCI enabled protocols.
     #[prost(message, repeated, tag="6")]
     pub entrypoints: ::prost::alloc::vec::Vec<EntryPoint>,
+    /// An array of entrypoint tracing parameteres. Used for DCI enabled protocols.
+    #[prost(message, repeated, tag="7")]
+    pub entrypoint_params: ::prost::alloc::vec::Vec<EntryPointParams>,
 }
 /// A set of storage changes aggregated by transaction.
 #[allow(clippy::derive_partial_eq_without_eq)]


### PR DESCRIPTION
Design decisions:
- each entrypoint needs to be linked to at least 1 protocol component. Therefore, component id should be a field in the entrypoint message. Entrypoints will need to be redefined again for each component you link to it.
- entrypoint parameters should be defined independent of protocol components. Therefore instead of defining them inside of the component's dynamic attributes, they should be defined separately and optionally linked to a component (helps with debugging etc).
- to enable the backwards compatibility of adding new tracing strategies, yet still provide structure to what data should be provided per strategy, we opted to use `oneof` to create a tracing data message enum. This can be extended at a later point for new strategies. Also the message struct clearly defines what data is needed for the chosen tracing type.