### PR TITLE
feat(DCI): Add DCI Entrypoints to BalancerV2 components

### DIFF
--- a/substreams/Cargo.lock
+++ b/substreams/Cargo.lock
@@ -243,18 +243,14 @@ name = "ethereum-balancer-v2"
 version = "0.2.5"
 dependencies = [
  "anyhow",
- "bytes",
  "ethabi 18.0.0",
  "getrandom",
  "hex",
- "hex-literal 0.4.1",
  "itertools 0.12.1",
  "num-bigint",
- "prost 0.11.9",
- "prost-types 0.12.6",
  "substreams",
  "substreams-ethereum",
- "tycho-substreams 0.2.1 (git+https://github.com/propeller-heads/tycho-protocol-sdk.git?rev=52d5021)",
+ "tycho-substreams 0.2.1 (git+https://github.com/propeller-heads/tycho-protocol-sdk.git?rev=51995f9)",
 ]
 
 [[package]]
@@ -1689,6 +1685,22 @@ dependencies = [
 [[package]]
 name = "tycho-substreams"
 version = "0.2.1"
+dependencies = [
+ "ethabi 18.0.0",
+ "hex",
+ "itertools 0.12.1",
+ "num-bigint",
+ "prost 0.11.9",
+ "serde",
+ "serde_json",
+ "substreams",
+ "substreams-ethereum",
+]
+
+[[package]]
+name = "tycho-substreams"
+version = "0.2.1"
+source = "git+https://github.com/propeller-heads/tycho-protocol-sdk.git?rev=51995f9#51995f9731ecf549a5ae68c281906c90efe9909a"
 dependencies = [
  "ethabi 18.0.0",
  "hex",

--- a/substreams/ethereum-balancer-v2/Cargo.toml
+++ b/substreams/ethereum-balancer-v2/Cargo.toml
@@ -10,16 +10,12 @@ crate-type = ["cdylib"]
 [dependencies]
 substreams = "0.5.22"
 substreams-ethereum = "0.9.9"
-prost = "0.11"
-prost-types = "0.12.3"
-hex-literal = "0.4.1"
 ethabi = "18.0.0"
 hex = "0.4.3"
-bytes = "1.5.0"
 anyhow = "1.0.75"
 num-bigint = "0.4.4"
 itertools = "0.12.0"
-tycho-substreams = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", rev = "52d5021" }
+tycho-substreams = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", rev = "51995f9" }
 
 [build-dependencies]
 anyhow = "1"

--- a/substreams/ethereum-balancer-v2/src/modules.rs
+++ b/substreams/ethereum-balancer-v2/src/modules.rs
@@ -9,7 +9,9 @@ use substreams::{
 };
 use substreams_ethereum::{pb::eth, Event};
 use tycho_substreams::{
-    balances::aggregate_balances_changes, contract::extract_contract_changes_builder, prelude::*,
+    attributes::json_deserialize_address_list, balances::aggregate_balances_changes,
+    block_storage::get_block_storage_changes, contract::extract_contract_changes_builder,
+    entrypoint::create_entrypoint, models::entry_point_params::TraceData, prelude::*,
 };
 
 pub const VAULT_ADDRESS: &[u8] = &hex!("BA12222222228d8Ba445958a75a0704d566BF2C8");
@@ -197,6 +199,29 @@ pub fn map_protocol_changes(
                 .components
                 .iter()
                 .for_each(|component| {
+                    let rate_providers = component
+                        .static_att
+                        .iter()
+                        .find(|att| att.name == "rate_providers")
+                        .map(|att| json_deserialize_address_list(&att.value));
+
+                    if let Some(rate_providers) = rate_providers {
+                        for rate_provider in rate_providers {
+                            let trace_data = TraceData::Rpc(RpcTraceData {
+                                caller: None,
+                                calldata: "0x679aefce".as_bytes().to_vec(), // getRate()
+                            });
+                            let (entrypoint, entrypoint_params) = create_entrypoint(
+                                rate_provider,
+                                "getRate()".to_string(),
+                                component.id.clone(),
+                                trace_data,
+                            );
+                            builder.add_entrypoint(&entrypoint);
+                            builder.add_entrypoint_params(&entrypoint_params);
+                        }
+                    }
+
                     builder.add_protocol_component(component);
                     let entity_change = EntityChanges {
                         component_id: component.id.clone(),
@@ -261,6 +286,8 @@ pub fn map_protocol_changes(
 
     // Process all `transaction_changes` for final output in the `BlockChanges`,
     //  sorted by transaction index (the key).
+    let block_storage_changes = get_block_storage_changes(&block);
+
     Ok(BlockChanges {
         block: Some((&block).into()),
         changes: transaction_changes
@@ -268,5 +295,6 @@ pub fn map_protocol_changes(
             .sorted_unstable_by_key(|(index, _)| *index)
             .filter_map(|(_, builder)| builder.build())
             .collect::<Vec<_>>(),
+        storage_changes: block_storage_changes,
     })
 }

--- a/testing/src/runner/runner.py
+++ b/testing/src/runner/runner.py
@@ -323,10 +323,10 @@ class TestRunner:
             for sell_token, buy_token in itertools.permutations(pool_state.tokens, 2):
                 for prctg in ["0.001", "0.01", "0.1"]:
                     # Try to sell 0.1% of the protocol balance
-                    sell_amount = (
-                        Decimal(prctg) * pool_state.balances[sell_token.address]
-                    )
                     try:
+                        sell_amount = (
+                                Decimal(prctg) * pool_state.balances[sell_token.address]
+                        )
                         amount_out, gas_used, _ = pool_state.get_amount_out(
                             sell_token, sell_amount, buy_token
                         )


### PR DESCRIPTION
Depends on: https://github.com/propeller-heads/tycho-protocol-sdk/pull/214

Adds DCI entrypoints for BalancerV2.
From the trace, the only required entrypoint is [getRate](https://github.com/balancer/balancer-v2-monorepo/blob/master/pkg/interfaces/contracts/pool-utils/IRateProvider.sol#L22)`- for each rate provider. 
Rate Providers are static attributes, so they can't change.