### PR TITLE
Fix Typos in Documentation Comments

### DIFF
--- a/evm/src/angle/AngleAdapter.sol
+++ b/evm/src/angle/AngleAdapter.sol
@@ -429,7 +429,7 @@ library LibManager {
         }
     }
 
-    /// @notice Calls a hook if needed after new funds have been transfered to a
+    /// @notice Calls a hook if needed after new funds have been transferred to a
     /// manager
     function invest(uint256 amount, bytes memory config) internal {
         (ManagerType managerType, bytes memory data) =

--- a/substreams/ethereum-balancer-v2/src/modules.rs
+++ b/substreams/ethereum-balancer-v2/src/modules.rs
@@ -153,7 +153,7 @@ pub fn store_balances(deltas: BlockBalanceDeltas, store: StoreAddBigInt) {
 /// This is the main map that handles most of the indexing of this substream.
 /// Every contract change is grouped by transaction index via the `transaction_changes`
 ///  map. Each block of code will extend the `TransactionChanges` struct with the
-///  cooresponding changes (balance, component, contract), inserting a new one if it doesn't exist.
+///  corresponding changes (balance, component, contract), inserting a new one if it doesn't exist.
 ///  At the very end, the map can easily be sorted by index to ensure the final
 /// `BlockChanges`  is ordered by transactions properly.
 #[substreams::handlers::map]


### PR DESCRIPTION


Description:  
This pull request corrects spelling mistakes in documentation comments across two files:
- In `AngleAdapter.sol`, the word "transfered" has been corrected to "transferred".
- In `modules.rs`, the word "cooresponding" has been corrected to "corresponding".

These changes improve the clarity and professionalism of the code documentation. No functional code has been modified.
