### PR TITLE
fix: skip processing balances of bpt tokens

### DIFF
--- a/substreams/Cargo.lock
+++ b/substreams/Cargo.lock
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "ethereum-balancer-v2"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "ethabi 18.0.0",

--- a/substreams/ethereum-balancer-v2/Cargo.toml
+++ b/substreams/ethereum-balancer-v2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum-balancer-v2"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 
 [lib]

--- a/substreams/ethereum-balancer-v2/src/pool_factories.rs
+++ b/substreams/ethereum-balancer-v2/src/pool_factories.rs
@@ -217,8 +217,8 @@ pub fn address_map(
             Some(
                 ProtocolComponent::new(&format!("0x{}", hex::encode(pool_registered.pool_id)))
                     .with_contracts(&[pool_created.pool.clone(), VAULT_ADDRESS.to_vec()])
-                    // .with_tokens(&tokens_registered.tokens) //TODO: does it make sense to include
-                    // BPT token here?
+                    // .with_tokens(&tokens_registered.tokens) // TODO: add this back if we need to
+                    // track BPT
                     .with_tokens(&[
                         create_call.main_token.clone(),
                         create_call.wrapped_token.clone(),

--- a/substreams/ethereum-balancer-v2/substreams.yaml
+++ b/substreams/ethereum-balancer-v2/substreams.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: "ethereum_balancer_v2"
-  version: v0.3.0
+  version: v0.3.1
   url: "https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/substreams/ethereum-balancer-v2"
 
 protobuf:


### PR DESCRIPTION
It was decided to disable BPT tokens on Balancer V2 (pools that double as their own pool token) as their balance handling is currently bugged. Because of this, we need to make sure we skip emitting any balance update messages for those tokens.