### PR TITLE
chore: bump tycho-substreams crate version

### DIFF
--- a/substreams/Cargo.lock
+++ b/substreams/Cargo.lock
@@ -1684,7 +1684,7 @@ dependencies = [
 
 [[package]]
 name = "tycho-substreams"
-version = "0.2.2"
+version = "0.4.0"
 dependencies = [
  "ethabi 18.0.0",
  "hex",

--- a/substreams/crates/tycho-substreams/Cargo.toml
+++ b/substreams/crates/tycho-substreams/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tycho-substreams"
-version = "0.2.2"
+version = "0.4.0"
 edition = "2021"
 description = "Tycho substreams development kit, contains tycho-indexer block changes model and helper functions for common indexing tasks."
 repository = "https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/substreams/crates/tycho-substreams"


### PR DESCRIPTION
This corresponds with the github release tag for DCI support.