### PR TITLE
fix: update sdk version for uniswapv3/v4 and ekubo

### DIFF
--- a/substreams/Cargo.lock
+++ b/substreams/Cargo.lock
@@ -311,9 +311,9 @@ dependencies = [
  "serde_qs",
  "substreams",
  "substreams-ethereum",
- "substreams-helper 0.0.2 (git+https://github.com/propeller-heads/tycho-protocol-sdk.git?rev=e4609be)",
+ "substreams-helper 0.0.2 (git+https://github.com/propeller-heads/tycho-protocol-sdk.git?tag=0.4.0)",
  "tiny-keccak",
- "tycho-substreams 0.2.0 (git+https://github.com/propeller-heads/tycho-protocol-sdk.git?rev=3c08359)",
+ "tycho-substreams 0.2.2",
 ]
 
 [[package]]
@@ -352,7 +352,7 @@ dependencies = [
  "substreams-ethereum",
  "substreams-helper 0.0.2 (git+https://github.com/propeller-heads/tycho-protocol-sdk.git?rev=b8aeaa3)",
  "tiny-keccak",
- "tycho-substreams 0.2.0 (git+https://github.com/propeller-heads/tycho-protocol-sdk.git?rev=b8aeaa3)",
+ "tycho-substreams 0.2.0",
 ]
 
 [[package]]
@@ -474,12 +474,12 @@ dependencies = [
  "substreams",
  "substreams-ethereum",
  "substreams-helper 0.0.2 (git+https://github.com/propeller-heads/tycho-protocol-sdk.git?rev=b8aeaa3)",
- "tycho-substreams 0.2.0 (git+https://github.com/propeller-heads/tycho-protocol-sdk.git?rev=b8aeaa3)",
+ "tycho-substreams 0.2.0",
 ]
 
 [[package]]
 name = "ethereum-uniswap-v3"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "ethabi 18.0.0",
@@ -491,14 +491,14 @@ dependencies = [
  "substreams",
  "substreams-entity-change",
  "substreams-ethereum",
- "substreams-helper 0.0.2 (git+https://github.com/propeller-heads/tycho-protocol-sdk.git?rev=b8aeaa3)",
+ "substreams-helper 0.0.2 (git+https://github.com/propeller-heads/tycho-protocol-sdk.git?tag=0.4.0)",
  "tiny-keccak",
- "tycho-substreams 0.2.0 (git+https://github.com/propeller-heads/tycho-protocol-sdk.git?rev=b8aeaa3)",
+ "tycho-substreams 0.2.2",
 ]
 
 [[package]]
 name = "ethereum-uniswap-v3-logs-only"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "ethabi 18.0.0",
@@ -511,14 +511,14 @@ dependencies = [
  "substreams",
  "substreams-entity-change",
  "substreams-ethereum",
- "substreams-helper 0.0.2 (git+https://github.com/propeller-heads/tycho-protocol-sdk.git?rev=b8aeaa3)",
+ "substreams-helper 0.0.2 (git+https://github.com/propeller-heads/tycho-protocol-sdk.git?tag=0.4.0)",
  "tiny-keccak",
- "tycho-substreams 0.2.0 (git+https://github.com/propeller-heads/tycho-protocol-sdk.git?rev=b8aeaa3)",
+ "tycho-substreams 0.2.2",
 ]
 
 [[package]]
 name = "ethereum-uniswap-v4"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "ethabi 18.0.0",
@@ -532,9 +532,9 @@ dependencies = [
  "substreams",
  "substreams-entity-change",
  "substreams-ethereum",
- "substreams-helper 0.0.2 (git+https://github.com/propeller-heads/tycho-protocol-sdk.git?rev=b8aeaa3)",
+ "substreams-helper 0.0.2 (git+https://github.com/propeller-heads/tycho-protocol-sdk.git?tag=0.4.0)",
  "tiny-keccak",
- "tycho-substreams 0.2.0 (git+https://github.com/propeller-heads/tycho-protocol-sdk.git?rev=b8aeaa3)",
+ "tycho-substreams 0.2.2",
 ]
 
 [[package]]
@@ -1509,6 +1509,29 @@ dependencies = [
 [[package]]
 name = "substreams-helper"
 version = "0.0.2"
+source = "git+https://github.com/propeller-heads/tycho-protocol-sdk.git?tag=0.4.0#cfbf6812bdc9503ff51debcf5e171cd680b4d694"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bigdecimal",
+ "downcast-rs",
+ "ethabi 18.0.0",
+ "hex",
+ "hex-literal 0.4.1",
+ "num-bigint",
+ "pad",
+ "prost 0.11.9",
+ "prost-types 0.12.6",
+ "substreams",
+ "substreams-entity-change",
+ "substreams-ethereum",
+ "thiserror 1.0.69",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "substreams-helper"
+version = "0.0.2"
 source = "git+https://github.com/propeller-heads/tycho-protocol-sdk.git?rev=52d5021#52d502198e9aa964814ef5f139df0886c3eb7bb0"
 dependencies = [
  "anyhow",
@@ -1533,29 +1556,6 @@ dependencies = [
 name = "substreams-helper"
 version = "0.0.2"
 source = "git+https://github.com/propeller-heads/tycho-protocol-sdk.git?rev=b8aeaa3#b8aeaa3dc6e7242a5dd23681921258ef2cb3c6dd"
-dependencies = [
- "anyhow",
- "base64",
- "bigdecimal",
- "downcast-rs",
- "ethabi 18.0.0",
- "hex",
- "hex-literal 0.4.1",
- "num-bigint",
- "pad",
- "prost 0.11.9",
- "prost-types 0.12.6",
- "substreams",
- "substreams-entity-change",
- "substreams-ethereum",
- "thiserror 1.0.69",
- "tiny-keccak",
-]
-
-[[package]]
-name = "substreams-helper"
-version = "0.0.2"
-source = "git+https://github.com/propeller-heads/tycho-protocol-sdk.git?rev=e4609be#e4609bed0bb3c73a13864a951b8cb64c523bc148"
 dependencies = [
  "anyhow",
  "base64",
@@ -1692,22 +1692,6 @@ dependencies = [
  "indexmap",
  "toml_datetime",
  "winnow",
-]
-
-[[package]]
-name = "tycho-substreams"
-version = "0.2.0"
-source = "git+https://github.com/propeller-heads/tycho-protocol-sdk.git?rev=3c08359#3c08359cf112e15c137dd5256b8dc8e9cd6c1626"
-dependencies = [
- "ethabi 18.0.0",
- "hex",
- "itertools 0.12.1",
- "num-bigint",
- "prost 0.11.9",
- "serde",
- "serde_json",
- "substreams",
- "substreams-ethereum",
 ]
 
 [[package]]

--- a/substreams/ethereum-ekubo-v2/Cargo.toml
+++ b/substreams/ethereum-ekubo-v2/Cargo.toml
@@ -10,8 +10,8 @@ crate-type = ["cdylib"]
 [dependencies]
 substreams = "0.5.22"
 substreams-ethereum = "0.9.9"
-substreams-helper = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", rev = "e4609be" }
-tycho-substreams = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", rev = "3c08359" }
+substreams-helper = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", tag = "0.4.0" }
+tycho-substreams = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", tag = "0.4.0" }
 prost = "0.11"
 anyhow = "1.0.95"
 ethabi = "18.0.0"

--- a/substreams/ethereum-ekubo-v2/src/modules/2_map_components.rs
+++ b/substreams/ethereum-ekubo-v2/src/modules/2_map_components.rs
@@ -40,9 +40,11 @@ fn map_components(block_tx_events: BlockTransactionEvents) -> BlockChanges {
                     contract_changes: vec![],
                     entity_changes: entities,
                     component_changes: components,
+                    ..Default::default()
                 })
             })
             .collect(),
+        ..Default::default()
     }
 }
 

--- a/substreams/ethereum-ekubo-v2/src/modules/6_map_protocol_changes.rs
+++ b/substreams/ethereum-ekubo-v2/src/modules/6_map_protocol_changes.rs
@@ -237,6 +237,7 @@ fn map_protocol_changes(
             .sorted_unstable_by_key(|(index, _)| *index)
             .filter_map(|(_, builder)| builder.build())
             .collect(),
+        ..Default::default()
     })
 }
 

--- a/substreams/ethereum-uniswap-v3-logs-only/Cargo.toml
+++ b/substreams/ethereum-uniswap-v3-logs-only/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum-uniswap-v3-logs-only"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 [lib]
@@ -14,8 +14,8 @@ prost = "0.11"
 ethabi = "18.0.0"
 anyhow = "1.0.75"
 hex-literal = "0.4.1"
-substreams-helper = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", rev = "b8aeaa3" }
-tycho-substreams = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", rev = "b8aeaa3" }
+substreams-helper = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", tag = "0.4.0" }
+tycho-substreams = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", tag = "0.4.0" }
 num-bigint = "0.4.4"
 hex = "0.4.3"
 tiny-keccak = "2.0"

--- a/substreams/ethereum-uniswap-v3-logs-only/base-uniswap-v3.yaml
+++ b/substreams/ethereum-uniswap-v3-logs-only/base-uniswap-v3.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: "base_uniswap_v3_logs_only"
-  version: v0.1.1
+  version: v0.1.2
   url: "https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/substreams/ethereum-uniswap-v3-logs-only"
 
 protobuf:

--- a/substreams/ethereum-uniswap-v3-logs-only/ethereum-uniswap-v3.yaml
+++ b/substreams/ethereum-uniswap-v3-logs-only/ethereum-uniswap-v3.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: "ethereum_uniswap_v3_logs_only"
-  version: v0.1.1
+  version: v0.1.2
   url: "https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/substreams/ethereum-uniswap-v3-logs-only"
 
 protobuf:

--- a/substreams/ethereum-uniswap-v3-logs-only/src/modules/1_map_pool_created.rs
+++ b/substreams/ethereum-uniswap-v3-logs-only/src/modules/1_map_pool_created.rs
@@ -83,7 +83,6 @@ fn get_new_pools(
                     attribute_schema: vec![],
                     implementation_type: ImplementationType::Custom.into(),
                 }),
-                tx: Some(tycho_tx),
             }],
             balance_changes: vec![
                 BalanceChange {

--- a/substreams/ethereum-uniswap-v3-logs-only/src/modules/4_map_and_store_liquidity.rs
+++ b/substreams/ethereum-uniswap-v3-logs-only/src/modules/4_map_and_store_liquidity.rs
@@ -20,7 +20,7 @@ pub fn store_pool_current_tick(events: Events, store: StoreSetInt64) {
         .into_iter()
         .filter_map(event_to_current_tick)
         .for_each(|(pool, ordinal, new_tick_index)| {
-            store.set(ordinal, format!("pool:{0}", pool), &new_tick_index.into())
+            store.set(ordinal, format!("pool:{pool}"), &new_tick_index.into())
         });
 }
 

--- a/substreams/ethereum-uniswap-v3-logs-only/src/modules/5_map_protocol_changes.rs
+++ b/substreams/ethereum-uniswap-v3-logs-only/src/modules/5_map_protocol_changes.rs
@@ -160,6 +160,7 @@ pub fn map_protocol_changes(
             .sorted_unstable_by_key(|(index, _)| *index)
             .filter_map(|(_, builder)| builder.build())
             .collect::<Vec<_>>(),
+        ..Default::default()
     })
 }
 

--- a/substreams/ethereum-uniswap-v3-logs-only/unichain-uniswap-v3.yaml
+++ b/substreams/ethereum-uniswap-v3-logs-only/unichain-uniswap-v3.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: "unichain_uniswap_v3"
-  version: v0.1.1
+  version: v0.1.2
   url: "https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/substreams/ethereum-uniswap-v3-logs-only"
 
 protobuf:

--- a/substreams/ethereum-uniswap-v3/Cargo.toml
+++ b/substreams/ethereum-uniswap-v3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum-uniswap-v3"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 
 [lib]
@@ -14,8 +14,8 @@ prost = "0.11"
 ethabi = "18.0.0"
 anyhow = "1.0.75"
 hex-literal = "0.4.1"
-substreams-helper = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", rev = "b8aeaa3" }
-tycho-substreams = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", rev = "b8aeaa3" }
+substreams-helper = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", tag = "0.4.0" }
+tycho-substreams = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", tag = "0.4.0" }
 num-bigint = "0.4.4"
 hex = "0.4.3"
 tiny-keccak = "2.0"

--- a/substreams/ethereum-uniswap-v3/arbitrum-uniswap-v3.yaml
+++ b/substreams/ethereum-uniswap-v3/arbitrum-uniswap-v3.yaml
@@ -1,9 +1,8 @@
 specVersion: v0.1.0
 package:
   name: "arbitrum_uniswap_v3"
-  version: v0.3.0
+  version: v0.3.1
   url: "https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/substreams/ethereum-uniswap-v3"
-
 
 protobuf:
   files:

--- a/substreams/ethereum-uniswap-v3/ethereum-uniswap-v3.yaml
+++ b/substreams/ethereum-uniswap-v3/ethereum-uniswap-v3.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: "ethereum_uniswap_v3"
-  version: v0.3.0
+  version: v0.3.1
   url: "https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/substreams/ethereum-uniswap-v3"
 
 protobuf:

--- a/substreams/ethereum-uniswap-v3/src/modules/1_map_pool_created.rs
+++ b/substreams/ethereum-uniswap-v3/src/modules/1_map_pool_created.rs
@@ -19,7 +19,7 @@ pub fn map_pools_created(
 
     get_new_pools(&block, &mut new_pools, factory_address);
 
-    Ok(BlockChanges { block: Some((&block).into()), changes: new_pools })
+    Ok(BlockChanges { block: Some((&block).into()), changes: new_pools, ..Default::default() })
 }
 
 // Extract new pools from PoolCreated events
@@ -83,9 +83,9 @@ fn get_new_pools(
                     attribute_schema: vec![],
                     implementation_type: ImplementationType::Custom.into(),
                 }),
-                tx: Some(tycho_tx),
             }],
             balance_changes: vec![],
+            ..Default::default()
         })
     };
 

--- a/substreams/ethereum-uniswap-v3/src/modules/5_map_pool_events.rs
+++ b/substreams/ethereum-uniswap-v3/src/modules/5_map_pool_events.rs
@@ -112,7 +112,7 @@ pub fn map_pool_events(
     let tycho_block: Block = (&block).into();
 
     let block_entity_changes =
-        BlockChanges { block: Some(tycho_block), changes: tx_entity_changes };
+        BlockChanges { block: Some(tycho_block), changes: tx_entity_changes, ..Default::default() };
 
     Ok(block_entity_changes)
 }
@@ -146,6 +146,7 @@ fn update_tx_changes_map(
             entity_changes,
             balance_changes,
             component_changes: vec![],
+            ..Default::default()
         };
         tx_changes_map.insert(tx_hash, tx_changes);
     }

--- a/substreams/ethereum-uniswap-v4/Cargo.toml
+++ b/substreams/ethereum-uniswap-v4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum-uniswap-v4"
-version = "0.2.0"
+version = "0.2.2"
 edition = "2021"
 
 [lib]
@@ -14,8 +14,8 @@ prost = "0.11"
 ethabi = "18.0.0"
 anyhow = "1.0.75"
 hex-literal = "0.4.1"
-substreams-helper = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", rev = "b8aeaa3" }
-tycho-substreams = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", rev = "b8aeaa3" }
+substreams-helper = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", tag = "0.4.0" }
+tycho-substreams = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", tag = "0.4.0" }
 num-bigint = "0.4.4"
 hex = "0.4.3"
 tiny-keccak = "2.0"

--- a/substreams/ethereum-uniswap-v4/base-uniswap-v4.yaml
+++ b/substreams/ethereum-uniswap-v4/base-uniswap-v4.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: "base_uniswap_v4"
-  version: v0.2.1
+  version: v0.2.2
   url: "https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/substreams/ethereum-uniswap-v4"
 
 protobuf:

--- a/substreams/ethereum-uniswap-v4/ethereum-uniswap-v4.yaml
+++ b/substreams/ethereum-uniswap-v4/ethereum-uniswap-v4.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: "ethereum_uniswap_v4"
-  version: v0.2.1
+  version: v0.2.2
   url: "https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/substreams/ethereum-uniswap-v4"
 
 protobuf:

--- a/substreams/ethereum-uniswap-v4/sepolia-uniswap-v4.yaml
+++ b/substreams/ethereum-uniswap-v4/sepolia-uniswap-v4.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: "ethereum_uniswap_v4"
-  version: v0.2.1
+  version: v0.2.2
   url: "https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/substreams/ethereum-uniswap-v4"
 
 protobuf:

--- a/substreams/ethereum-uniswap-v4/src/modules/1_map_pool_created.rs
+++ b/substreams/ethereum-uniswap-v4/src/modules/1_map_pool_created.rs
@@ -111,7 +111,6 @@ fn get_new_pools(
                     attribute_schema: vec![],
                     implementation_type: ImplementationType::Custom.into(),
                 }),
-                tx: Some(tycho_tx),
             }],
             balance_changes: vec![
                 BalanceChange {

--- a/substreams/ethereum-uniswap-v4/src/modules/4_store_current_sqrtprice.rs
+++ b/substreams/ethereum-uniswap-v4/src/modules/4_store_current_sqrtprice.rs
@@ -17,7 +17,7 @@ pub fn store_pool_current_sqrt_price(events: Events, store: StoreSetBigInt) {
         .into_iter()
         .filter_map(event_to_current_sqrt_price)
         .for_each(|(pool, ordinal, new_tick_index)| {
-            store.set(ordinal, format!("pool:{0}", pool), &new_tick_index)
+            store.set(ordinal, format!("pool:{pool}"), &new_tick_index)
         });
 }
 

--- a/substreams/ethereum-uniswap-v4/src/modules/4_store_current_tick.rs
+++ b/substreams/ethereum-uniswap-v4/src/modules/4_store_current_tick.rs
@@ -14,7 +14,7 @@ pub fn store_pool_current_tick(events: Events, store: StoreSetInt64) {
         .into_iter()
         .filter_map(event_to_current_tick)
         .for_each(|(pool, ordinal, new_tick_index)| {
-            store.set(ordinal, format!("pool:{0}", pool), &new_tick_index.into())
+            store.set(ordinal, format!("pool:{pool}"), &new_tick_index.into())
         });
 }
 fn event_to_current_tick(event: PoolEvent) -> Option<(String, u64, i32)> {

--- a/substreams/ethereum-uniswap-v4/src/modules/6_map_protocol_changes.rs
+++ b/substreams/ethereum-uniswap-v4/src/modules/6_map_protocol_changes.rs
@@ -160,6 +160,7 @@ pub fn map_protocol_changes(
             .sorted_unstable_by_key(|(index, _)| *index)
             .filter_map(|(_, builder)| builder.build())
             .collect::<Vec<_>>(),
+        ..Default::default()
     })
 }
 

--- a/substreams/ethereum-uniswap-v4/unichain-uniswap-v4.yaml
+++ b/substreams/ethereum-uniswap-v4/unichain-uniswap-v4.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: "unichain_uniswap_v4"
-  version: v0.2.1
+  version: v0.2.2
   url: "https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/substreams/ethereum-uniswap-v4"
 
 protobuf:


### PR DESCRIPTION
This is following the bugfix in https://github.com/propeller-heads/tycho-protocol-sdk/pull/213

Ekubo version has already be bumped in previous upgrade PR