### PR TITLE
feat: change version of github actions/checkout to v5

### DIFF
--- a/.github/workflows/evm.yml
+++ b/.github/workflows/evm.yml
@@ -19,7 +19,7 @@ jobs:
       run:
         working-directory: evm
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 

--- a/.github/workflows/substream.cd.yaml
+++ b/.github/workflows/substream.cd.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 

--- a/.github/workflows/substream.ci.yaml
+++ b/.github/workflows/substream.ci.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 


### PR DESCRIPTION
[INFRA-158](https://propeller-heads.atlassian.net/browse/INFRA-158) - update ci/cd github **actions/checkout** to v5 due to upgrade ci/cd runner

[INFRA-158]: https://propeller-heads.atlassian.net/browse/INFRA-158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ