### PR TITLE
feat: Add previous_value field to ContractSlot

### DIFF
--- a/proto/tycho/evm/v1/common.proto
+++ b/proto/tycho/evm/v1/common.proto
@@ -123,6 +123,8 @@ message ContractSlot {
   bytes slot = 2;
   // The new value for this storage slot.
   bytes value = 3;
+  // The old value of this storage slot
+  bytes previous_value = 4;
 }
 
 // A struct for following the token balance changes for a contract.

--- a/substreams/crates/tycho-substreams/src/block_storage.rs
+++ b/substreams/crates/tycho-substreams/src/block_storage.rs
@@ -56,7 +56,11 @@ pub fn get_block_storage_changes(block: &eth::v2::Block) -> Vec<TransactionStora
                 for change in changes {
                     latest_changes.insert(
                         change.key.clone(),
-                        ContractSlot { slot: change.key, value: change.new_value },
+                        ContractSlot {
+                            slot: change.key,
+                            value: change.new_value,
+                            previous_value: change.old_value,
+                        },
                     );
                 }
 

--- a/substreams/crates/tycho-substreams/src/models.rs
+++ b/substreams/crates/tycho-substreams/src/models.rs
@@ -72,7 +72,7 @@ impl TransactionChangesBuilder {
     }
 
     /// Unique contract/account addresses that have been changed so far.
-    pub fn changed_contracts(&self) -> impl Iterator<Item=&[u8]> {
+    pub fn changed_contracts(&self) -> impl Iterator<Item = &[u8]> {
         self.contract_changes
             .keys()
             .map(|k| k.as_slice())

--- a/substreams/crates/tycho-substreams/src/models.rs
+++ b/substreams/crates/tycho-substreams/src/models.rs
@@ -72,7 +72,7 @@ impl TransactionChangesBuilder {
     }
 
     /// Unique contract/account addresses that have been changed so far.
-    pub fn changed_contracts(&self) -> impl Iterator<Item = &[u8]> {
+    pub fn changed_contracts(&self) -> impl Iterator<Item=&[u8]> {
         self.contract_changes
             .keys()
             .map(|k| k.as_slice())
@@ -124,7 +124,7 @@ impl TransactionChangesBuilder {
                     .attributes
                     .clone()
                     .iter()
-                    .filter(|&attr| (attr.change == i32::from(ChangeType::Creation)))
+                    .filter(|&attr| attr.change == i32::from(ChangeType::Creation))
                     .map(|attr| attr.name.clone())
                     .collect(),
             });
@@ -578,7 +578,11 @@ impl From<InterimContractChange> for Option<ContractChange> {
                 .slots
                 .into_iter()
                 .filter(|(_, value)| value.has_changed())
-                .map(|(slot, value)| ContractSlot { slot, value: value.new_value })
+                .map(|(slot, value)| ContractSlot {
+                    slot,
+                    value: value.new_value,
+                    previous_value: value.start_value,
+                })
                 .collect(),
             change: value.change.into(),
             token_balances: value

--- a/substreams/crates/tycho-substreams/src/pb/tycho.evm.v1.rs
+++ b/substreams/crates/tycho-substreams/src/pb/tycho.evm.v1.rs
@@ -138,6 +138,9 @@ pub struct ContractSlot {
     /// The new value for this storage slot.
     #[prost(bytes="vec", tag="3")]
     pub value: ::prost::alloc::vec::Vec<u8>,
+    /// The old value of this storage slot
+    #[prost(bytes="vec", tag="4")]
+    pub previous_value: ::prost::alloc::vec::Vec<u8>,
 }
 /// A struct for following the token balance changes for a contract.
 #[allow(clippy::derive_partial_eq_without_eq)]


### PR DESCRIPTION
This change is required by the DCI to properly detect potential address changes (retriggers) on packed storage slots.