### PR TITLE
feat(Testing SDK): Pass adapter path to decoder

### DIFF
--- a/protocol-testing/Cargo.lock
+++ b/protocol-testing/Cargo.lock
@@ -7758,9 +7758,9 @@ dependencies = [
 
 [[package]]
 name = "tycho-client"
-version = "0.83.0"
+version = "0.82.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68faa54caad8f18d764acc300564b3d468e32eb63c67219cea7429a21b71cac9"
+checksum = "19a7ed885ea7e01efc3c98135b1be5c0472e81ada6455517f61ca67313271587"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7785,9 +7785,9 @@ dependencies = [
 
 [[package]]
 name = "tycho-common"
-version = "0.83.0"
+version = "0.82.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e031808e0cc6fe9d6402a46277464dc224c174aee40eb07122ed38bbbe2a3c65"
+checksum = "096c87ebe011785fcd7ed59ec501ac12b465a64fbd2914b8c0c57125c253682b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7810,7 +7810,7 @@ dependencies = [
 
 [[package]]
 name = "tycho-simulation"
-version = "0.155.0"
+version = "0.155.2"
 dependencies = [
  "alloy",
  "async-stream",

--- a/protocol-testing/Cargo.toml
+++ b/protocol-testing/Cargo.toml
@@ -9,8 +9,8 @@ miette = { version = "7.6.0", features = ["fancy"] }
 # Logging & Tracing
 tracing = "0.1.37"
 # Tycho dependencies
-tycho-common = "0.83.0"
-tycho-client = "0.83.0"
+tycho-common = "0.82.0"
+tycho-client = "0.82.0"
 # TODO make this less hacky. We should probably try to build this in a similar way that the indexer is built
 tycho-simulation = { path = "../../tycho-simulation", features = ["evm"] }
 # EVM dependencies

--- a/protocol-testing/src/config.rs
+++ b/protocol-testing/src/config.rs
@@ -48,8 +48,8 @@ impl ProtocolComponentExpectation {
             match other_value {
                 Some(other_value) => {
                     if value != other_value {
-                        let self_value = format!("{:?}", value);
-                        let other_value = format!("{:?}", other_value);
+                        let self_value = format!("{value:?}");
+                        let other_value = format!("{other_value:?}");
                         let diff = self.format_diff(
                             "static_attributes",
                             &self_value,

--- a/protocol-testing/src/test_runner.rs
+++ b/protocol-testing/src/test_runner.rs
@@ -28,6 +28,7 @@ use tycho_simulation::{
 };
 
 use crate::{
+    adapter_builder::AdapterContractBuilder,
     config::{IntegrationTest, IntegrationTestsConfig, ProtocolComponentWithTestConfig},
     rpc::RPCProvider,
     tycho_rpc::TychoClient,
@@ -40,12 +41,17 @@ pub struct TestRunner {
     db_url: String,
     vm_traces: bool,
     substreams_path: PathBuf,
+    adapter_contract_builder: AdapterContractBuilder,
 }
 
 impl TestRunner {
     pub fn new(package: String, tycho_logs: bool, db_url: String, vm_traces: bool) -> Self {
         let substreams_path = PathBuf::from("../substreams").join(&package);
-        Self { tycho_logs, db_url, vm_traces, substreams_path }
+        let repo_root = env::current_dir().expect("Failed to get current directory");
+        let evm_path = repo_root.join("../evm");
+        let adapter_contract_builder =
+            AdapterContractBuilder::new(evm_path.to_string_lossy().to_string());
+        Self { tycho_logs, db_url, vm_traces, substreams_path, adapter_contract_builder }
     }
 
     pub fn run_tests(&self) -> miette::Result<()> {
@@ -96,7 +102,7 @@ impl TestRunner {
 
     fn parse_config(config_yaml_path: &PathBuf) -> miette::Result<IntegrationTestsConfig> {
         info!("Config YAML: {}", config_yaml_path.display());
-        let yaml = Yaml::file(&config_yaml_path);
+        let yaml = Yaml::file(config_yaml_path);
         let figment = Figment::new().merge(yaml);
         let config = figment
             .extract::<IntegrationTestsConfig>()
@@ -145,7 +151,16 @@ impl TestRunner {
             .wrap_err("Failed to run Tycho")?;
 
         let _ = tycho_runner.run_with_rpc_server(
-            validate_state,
+            |expected_components, start_block, stop_block, skip_balance_check| {
+                validate_state(
+                    expected_components,
+                    start_block,
+                    stop_block,
+                    skip_balance_check,
+                    config,
+                    &self.adapter_contract_builder,
+                )
+            },
             &test.expected_components,
             test.start_block,
             test.stop_block,
@@ -176,6 +191,8 @@ fn validate_state(
     start_block: u64,
     stop_block: u64,
     skip_balance_check: bool,
+    config: &IntegrationTestsConfig,
+    adapter_contract_builder: &AdapterContractBuilder,
 ) -> miette::Result<()> {
     let rt = Runtime::new().unwrap();
 
@@ -263,8 +280,36 @@ fn validate_state(
     }
 
     // Step 3: Run Tycho Simulation
+
+    // Build/find the adapter contract
+    let adapter_contract_path =
+        match adapter_contract_builder.find_contract(&config.adapter_contract) {
+            Ok(path) => {
+                info!("Found adapter contract at: {}", path.display());
+                path
+            }
+            Err(_) => {
+                info!("Adapter contract not found, building it...");
+                adapter_contract_builder
+                    .build_target(
+                        &config.adapter_contract,
+                        config
+                            .adapter_build_signature
+                            .as_deref(),
+                        config.adapter_build_args.as_deref(),
+                    )
+                    .wrap_err("Failed to build adapter contract")?
+            }
+        };
+
+    info!("Using adapter contract: {}", adapter_contract_path.display());
+    let adapter_contract_path_str: &str = adapter_contract_path.to_str().unwrap();
+
     let mut decoder = TychoStreamDecoder::new();
-    decoder.register_decoder::<EVMPoolState<PreCachedDB>>("test_protocol");
+    decoder.register_decoder::<EVMPoolState<PreCachedDB>>(
+        "test_protocol",
+        Some(adapter_contract_path_str),
+    );
 
     // Mock a stream message, with only a Snapshot and no deltas
     let mut states: HashMap<String, ComponentWithState> = HashMap::new();

--- a/protocol-testing/src/tycho_rpc.rs
+++ b/protocol-testing/src/tycho_rpc.rs
@@ -21,8 +21,8 @@ pub enum RpcError {
 impl fmt::Display for RpcError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            RpcError::ClientError(msg) => write!(f, "RPC client error: {}", msg),
-            RpcError::ResponseError(msg) => write!(f, "RPC response error: {}", msg),
+            RpcError::ClientError(msg) => write!(f, "RPC client error: {msg}"),
+            RpcError::ResponseError(msg) => write!(f, "RPC response error: {msg}"),
         }
     }
 }

--- a/protocol-testing/src/tycho_runner.rs
+++ b/protocol-testing/src/tycho_runner.rs
@@ -129,10 +129,12 @@ impl TychoRunner {
                     debug!("Received termination message, stopping RPC server...");
                     cmd.kill()
                         .expect("Failed to kill RPC server");
+                    let _ = cmd.wait();
                 }
                 Err(_) => {
                     // Channel closed, terminate anyway
                     let _ = cmd.kill();
+                    let _ = cmd.wait();
                 }
             }
         });
@@ -160,7 +162,7 @@ impl TychoRunner {
             thread::spawn(move || {
                 let reader = BufReader::new(stdout);
                 for line in reader.lines().map_while(Result::ok) {
-                    println!("{}", line);
+                    println!("{line}");
                 }
             });
         }
@@ -169,7 +171,7 @@ impl TychoRunner {
             thread::spawn(move || {
                 let reader = BufReader::new(stderr);
                 for line in reader.lines().map_while(Result::ok) {
-                    eprintln!("{}", line);
+                    eprintln!("{line}");
                 }
             });
         }

--- a/protocol-testing/src/utils.rs
+++ b/protocol-testing/src/utils.rs
@@ -48,8 +48,7 @@ pub fn build_spkg(yaml_file_path: &PathBuf, initial_block: u64) -> miette::Resul
         .expect("Version not found on YAML");
 
     let package_version = binding.as_str().unwrap_or("");
-
-    let spkg_name = format!("{}/{}-{}.spkg", parent_dir, package_name, package_version);
+    let spkg_name = format!("{parent_dir}/{package_name}-{package_version}.spkg");
 
     // Write the modified YAML back to the file
     let yaml_string = serde_yaml::to_string(&data).into_diagnostic()?;


### PR DESCRIPTION
```
2025-09-05T15:21:59.566185Z  INFO Found 1 protocol components
2025-09-05T15:21:59.566206Z  INFO Found 1 protocol states
2025-09-05T15:21:59.566209Z  INFO Validating state...
2025-09-05T15:21:59.566244Z  INFO Component 0xe96a45f66bdda121b24f0a861372a72e8889523d00020000000000000000069b matches the expected state
2025-09-05T15:21:59.566248Z  INFO All expected components were successfully found on Tycho and match the expected state
2025-09-05T15:21:59.566251Z  INFO Skipping balance check
2025-09-05T15:21:59.566366Z  INFO Found adapter contract at: /Users/tamaralipowski/Code/tycho-protocol-sdk/protocol-testing/../evm/out/BalancerV2SwapAdapter.sol/BalancerV2SwapAdapter.evm.runtime
2025-09-05T15:21:59.566372Z  INFO Using adapter contract: /Users/tamaralipowski/Code/tycho-protocol-sdk/protocol-testing/../evm/out/BalancerV2SwapAdapter.sol/BalancerV2SwapAdapter.evm.runtime
2025-09-05T15:21:59.566556Z  INFO Loading tokens from Tycho...
2025-09-05T15:21:59.581803Z  INFO Loaded 3 tokens
2025-09-05T15:21:59.581886Z  INFO Processing 2 contracts from snapshots
2025-09-05T15:21:59.627410Z  INFO Updating engine with 2 contracts from snapshots
2025-09-05T15:21:59.636310Z  INFO Engine updated
2025-09-05T15:21:59.651784Z  INFO Decoded 1 snapshots for protocol test_protocol
2025-09-05T15:21:59.658871Z  INFO Amount out for 0xe96a45f66bdda121b24f0a861372a72e8889523d00020000000000000000069b: calculating for tokens "TRUF/LINK"
2025-09-05T15:21:59.658955Z  INFO Spot price "TRUF/LINK": 0.019475844913286314
2025-09-05T15:21:59.658962Z  INFO 
✅ Simulation validation passed.
```

This was the most elegant solution we could come up with at the moment for having the proper adapter in the builder.

Notes:
- The default adapter bytecode in tycho-simulation is still loaded at compile time.
- If the adapter bytecode is passed to the decoder, it will be loaded dynamically at runtime and used instead the bytecodes in tycho-simulation.
- The adapter bytecode is used in the builder to get capabilities and thus spot prices before returning the state, so just overwriting the adapter in the state is way too cumbersome. We went with this solution since it was the lesser evil, even though we know it leaks VM-specific info to non-vm protocols (which was already being done anyway with the balances).