### PR TITLE
feat: Rust testing SDK - implement get_amount_out simulation

### DIFF
--- a/protocol-testing/Cargo.lock
+++ b/protocol-testing/Cargo.lock
@@ -7821,8 +7821,7 @@ dependencies = [
 
 [[package]]
 name = "tycho-simulation"
-version = "0.156.0"
-source = "git+https://github.com/propeller-heads/tycho-simulation.git?tag=0.156.0#1983a787440e8ae757626d808a6e619baffc52f2"
+version = "0.155.2"
 dependencies = [
  "alloy",
  "async-stream",

--- a/protocol-testing/Cargo.lock
+++ b/protocol-testing/Cargo.lock
@@ -5429,6 +5429,8 @@ dependencies = [
  "glob",
  "hex",
  "miette",
+ "num-bigint",
+ "num-traits",
  "postgres",
  "serde",
  "serde_json",

--- a/protocol-testing/Cargo.lock
+++ b/protocol-testing/Cargo.lock
@@ -5428,6 +5428,7 @@ dependencies = [
  "figment",
  "glob",
  "hex",
+ "itertools 0.14.0",
  "miette",
  "num-bigint",
  "num-traits",
@@ -7823,8 +7824,8 @@ dependencies = [
 
 [[package]]
 name = "tycho-simulation"
-version = "0.156.0"
-source = "git+https://github.com/propeller-heads/tycho-simulation.git?tag=0.156.0#1983a787440e8ae757626d808a6e619baffc52f2"
+version = "0.157.0"
+source = "git+https://github.com/propeller-heads/tycho-simulation.git?tag=0.157.0#99645b43b5187b92f56823564bf1701002fd43ca"
 dependencies = [
  "alloy",
  "async-stream",

--- a/protocol-testing/Cargo.lock
+++ b/protocol-testing/Cargo.lock
@@ -7823,7 +7823,8 @@ dependencies = [
 
 [[package]]
 name = "tycho-simulation"
-version = "0.155.2"
+version = "0.156.0"
+source = "git+https://github.com/propeller-heads/tycho-simulation.git?tag=0.156.0#1983a787440e8ae757626d808a6e619baffc52f2"
 dependencies = [
  "alloy",
  "async-stream",

--- a/protocol-testing/Cargo.toml
+++ b/protocol-testing/Cargo.toml
@@ -11,7 +11,7 @@ tracing = "0.1.37"
 # Tycho dependencies
 tycho-common = "0.82.0"
 tycho-client = "0.82.0"
-tycho-simulation = { git = "https://github.com/propeller-heads/tycho-simulation.git", tag = "0.156.0", features = ["evm"] }
+tycho-simulation = { git = "https://github.com/propeller-heads/tycho-simulation.git", tag = "0.157.0", features = ["evm"] }
 ## TODO: for local development
 #tycho-simulation = { path = "../../tycho-simulation" }
 num-bigint = "0.4"
@@ -32,3 +32,4 @@ async-trait = "0.1.87"
 colored = "3.0.0"
 similar = "2.7.0"
 termsize = "0.1.9"
+itertools = "0.14.0"

--- a/protocol-testing/Cargo.toml
+++ b/protocol-testing/Cargo.toml
@@ -14,6 +14,8 @@ tycho-client = "0.82.0"
 tycho-simulation = { git = "https://github.com/propeller-heads/tycho-simulation.git", tag = "0.156.0", features = ["evm"] }
 ## TODO: for local development
 #tycho-simulation = { path = "../../tycho-simulation" }
+num-bigint = "0.4"
+num-traits = "0.2"
 # EVM dependencies
 alloy = { version = "1.0.27", features = ["arbitrary", "json", "dyn-abi", "sol-types", "contract", "provider-http"] }
 tokio = { version = "1", features = ["full"] }

--- a/protocol-testing/src/rpc.rs
+++ b/protocol-testing/src/rpc.rs
@@ -4,6 +4,7 @@ use alloy::{
     eips::eip1898::BlockId,
     primitives::{address, Address, U256},
     providers::{Provider, ProviderBuilder},
+    rpc::types::Block,
     transports::http::reqwest::Url,
 };
 use miette::{IntoDiagnostic, WrapErr};

--- a/protocol-testing/src/rpc.rs
+++ b/protocol-testing/src/rpc.rs
@@ -129,7 +129,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn get_block_header_test() {
+    async fn get_block_header() {
         let eth_rpc_url = env::var("RPC_URL").expect("Missing RPC_URL in environment");
 
         let rpc_provider = RPCProvider::new(eth_rpc_url);
@@ -142,8 +142,6 @@ mod tests {
 
         // Verify that we got a block with the correct number
         assert_eq!(block_number, block_header.header.number);
-
-        // Verify that the timestamp is non-zero
-        assert!(block_header.header.timestamp > 0);
+        assert_eq!(block_header.header.timestamp, 1741393115);
     }
 }

--- a/protocol-testing/src/test_runner.rs
+++ b/protocol-testing/src/test_runner.rs
@@ -336,11 +336,6 @@ fn validate_state(
         decoder_context,
     );
 
-    // NOTE: Once tycho-simulation is updated, you can use the new API like this:
-    // use tycho_simulation::protocol::models::DecoderContext;
-    // let context = DecoderContext::new().vm_adapter_path(adapter_contract_path_str);
-    // decoder.register_decoder_with_context::<EVMPoolState<PreCachedDB>>("test_protocol", context);
-
     // Mock a stream message, with only a Snapshot and no deltas
     let mut states: HashMap<String, ComponentWithState> = HashMap::new();
     for (id, component) in components_by_id {

--- a/protocol-testing/src/test_runner.rs
+++ b/protocol-testing/src/test_runner.rs
@@ -109,7 +109,7 @@ impl TestRunner {
                 }
                 Err(e) => {
                     failed_tests.push(test.name.clone());
-                    error!("❗️{} failed: {}\n", test.name, e);
+                    error!("❗️{} failed: {:?}\n", test.name, e);
                 }
             }
 
@@ -176,7 +176,7 @@ impl TestRunner {
             )
             .wrap_err("Failed to run Tycho")?;
 
-        let _ = tycho_runner.run_with_rpc_server(
+        tycho_runner.run_with_rpc_server(
             |expected_components, start_block, stop_block, skip_balance_check| {
                 validate_state(
                     expected_components,
@@ -191,9 +191,7 @@ impl TestRunner {
             test.start_block,
             test.stop_block,
             skip_balance_check,
-        )?;
-
-        Ok(())
+        )?
     }
 
     fn empty_database(&self) -> Result<(), Error> {
@@ -406,55 +404,54 @@ fn validate_state(
             state
                 .spot_price(&tokens[0], &tokens[1])
                 .map(|price| info!("Spot price {:?}: {:?}", formatted_token_str, price))
-                .map_err(|e| info!("Error calculating spot price for Pool {:?}: {:?}", id, e))
-                .ok();
+                .into_diagnostic()
+                .wrap_err(format!("Error calculating spot price for Pool {id:?}."))?;
 
             // Test get_amount_out with different percentages of limits. The reserves or limits are
             // relevant because we need to know how much to test with. We don’t know if a pool is
             // going to revert with 10 or 10 million USDC, for example, so by using the limits we
             // can use “safe values” where the sim shouldn’t break.
+            // We then retrieve the amount out for 0.1%, 1% and 10%.
             let percentages = [0.001, 0.01, 0.1];
+            // Get limits for this token pair
+            let (max_input, max_output) = state
+                .get_limits(tokens[0].address.clone(), tokens[1].address.clone())
+                .into_diagnostic()
+                .wrap_err(format!("Error getting limits for Pool {id:?}."))?;
+
+            info!("Retrieved limits for pool {id}. | Max input: {max_input} {} | Max output: {max_output} {}", tokens[0].symbol, tokens[1].symbol);
+
             for percentage in &percentages {
-                // Get limits for this token pair
-                let limits = state
-                    .get_limits(tokens[0].address.clone(), tokens[1].address.clone())
-                    .map_err(|e| info!("Error getting limits for Pool {:?}: {:?}", id, e))
-                    .ok();
+                // For precision, multiply by 1000 then divide by 1000
+                let percentage_biguint = BigUint::from((percentage * 1000.0) as u32);
+                let thousand = BigUint::from(1000u32);
+                let amount_in = (&max_input * &percentage_biguint) / &thousand;
 
-                if let Some((max_input, _max_output)) = limits {
-                    // Calculate test amount as percentage of max input
-                    let percentage_biguint = BigUint::from((percentage * 1000.0) as u32);
-                    let thousand = BigUint::from(1000u32);
-                    let amount_in = (&max_input * &percentage_biguint) / &thousand;
-
-                    // Skip if amount is zero
-                    if amount_in.is_zero() {
-                        continue;
-                    }
-
-                    state
-                        .get_amount_out(amount_in.clone(), &tokens[0], &tokens[1])
-                        .map(|result| {
-                            info!(
-                                "Amount out for trading {:.1}% of max ({} -> {}): {} {} (gas: {})",
-                                percentage * 100.0,
-                                &tokens[0].symbol,
-                                &tokens[1].symbol,
-                                result.amount,
-                                &tokens[1].symbol,
-                                result.gas
-                            )
-                        })
-                        .map_err(|e| {
-                            info!(
-                                "Error calculating amount out for Pool {:?} at {:.1}%: {:?}",
-                                id,
-                                percentage * 100.0,
-                                e
-                            )
-                        })
-                        .ok();
+                // Skip if amount is zero
+                if amount_in.is_zero() {
+                    info!("Amount in multiplied by percentage {percentage} is zero. Skipping pool {id}.");
+                    continue;
                 }
+
+                state
+                    .get_amount_out(amount_in.clone(), &tokens[0], &tokens[1])
+                    .map(|result| {
+                        info!(
+                            "Amount out for trading {:.1}% of max: ({} {} -> {} {}) (gas: {})",
+                            percentage * 100.0,
+                            amount_in,
+                            &tokens[0].symbol,
+                            result.amount,
+                            &tokens[1].symbol,
+                            result.gas
+                        )
+                    })
+                    .into_diagnostic()
+                    .wrap_err(format!(
+                        "Error calculating amount out for Pool {:?} at {:.1}%.",
+                        id,
+                        percentage * 100.0,
+                    ))?;
             }
         }
     }

--- a/protocol-testing/src/test_runner.rs
+++ b/protocol-testing/src/test_runner.rs
@@ -329,6 +329,10 @@ fn validate_state(
     info!("Using adapter contract: {}", adapter_contract_path.display());
     let adapter_contract_path_str: &str = adapter_contract_path.to_str().unwrap();
 
+    // Clear the shared database state to ensure test isolation
+    // This prevents state from previous tests from affecting the current test
+    tycho_simulation::evm::engine_db::SHARED_TYCHO_DB.clear();
+
     let mut decoder = TychoStreamDecoder::new();
     let decoder_context = DecoderContext::new().vm_adapter_path(adapter_contract_path_str);
     decoder.register_decoder_with_context::<EVMPoolState<PreCachedDB>>(

--- a/protocol-testing/src/test_runner.rs
+++ b/protocol-testing/src/test_runner.rs
@@ -5,6 +5,7 @@ use figment::{
     providers::{Format, Yaml},
     Figment,
 };
+use itertools::Itertools;
 use miette::{miette, IntoDiagnostic, WrapErr};
 use num_bigint::BigUint;
 use num_traits::Zero;
@@ -457,8 +458,12 @@ fn validate_state(
             // We then retrieve the amount out for 0.1%, 1% and 10%.
             let percentages = [0.001, 0.01, 0.1];
 
-            // Test both swap directions
-            let swap_directions = [(&tokens[0], &tokens[1]), (&tokens[1], &tokens[0])];
+            // Test all permutations of swap directions
+            let swap_directions: Vec<_> = tokens
+                .iter()
+                .permutations(2)
+                .map(|perm| (perm[0], perm[1]))
+                .collect();
 
             for (token_in, token_out) in &swap_directions {
                 let (max_input, max_output) = state

--- a/protocol-testing/src/test_runner.rs
+++ b/protocol-testing/src/test_runner.rs
@@ -336,22 +336,53 @@ fn validate_state(
         decoder_context,
     );
 
+    // Filter out components that have skip_simulation = true (match Python behavior)
+    let simulation_component_ids: std::collections::HashSet<String> = expected_components
+        .iter()
+        .filter(|c| !c.skip_simulation)
+        .map(|c| c.base.id.clone())
+        .collect();
+
+    info!("Components to simulate: {}", simulation_component_ids.len());
+    for id in &simulation_component_ids {
+        info!("  Simulating component: {}", id);
+    }
+
+    if simulation_component_ids.is_empty() {
+        info!("No components to simulate, skipping simulation validation");
+        return Ok(());
+    }
+
     // Mock a stream message, with only a Snapshot and no deltas
     let mut states: HashMap<String, ComponentWithState> = HashMap::new();
-    for (id, component) in components_by_id {
-        let component_id = &id.clone();
+    for (id, component) in &components_by_id {
+        let component_id = id;
+
+        // Only include components that should be simulated
+        if !simulation_component_ids.contains(component_id) {
+            continue;
+        }
+
         let state = protocol_states_by_id
             .get(component_id)
-            .wrap_err("Failed to get state for component")?
+            .wrap_err("Failed to get state for component"
+            )?
             .clone();
-        let component_with_state =
-            ComponentWithState { state, component, component_tvl: None, entrypoints: vec![] }; // TODO
+
+        let component_with_state = ComponentWithState {
+            state,
+            component: component.clone(),
+            component_tvl: None,
+            entrypoints: vec![],
+        }; // TODO
         states.insert(component_id.clone(), component_with_state);
     }
+    // Convert vm_storages to a HashMap - match Python behavior exactly
     let vm_storage: HashMap<Bytes, ResponseAccount> = vm_storages
         .into_iter()
         .map(|x| (x.address.clone(), x))
         .collect();
+
     let snapshot = Snapshot { states, vm_storage };
 
     let bytes = [0u8; 32];
@@ -414,6 +445,8 @@ fn validate_state(
             // We then retrieve the amount out for 0.1%, 1% and 10%.
             let percentages = [0.001, 0.01, 0.1];
             // Get limits for this token pair
+            // TODO do this again, but reverse the order of the tokens to get the opposite swap
+            // direction
             let (max_input, max_output) = state
                 .get_limits(tokens[0].address.clone(), tokens[1].address.clone())
                 .into_diagnostic()


### PR DESCRIPTION
Matches python side.
A few major things I've fixed other than the get_amount_out implementation:

1. Don't say it passed when the test failed.
2. Skip simulation if yaml says so.
3. Don't leak account storages between tests.

You can ignore the first commit - this was already taken care of in a separate PR and is just a weird rebase.

Example output for our most mischievous test:
```
2025-09-09T21:58:49.185043Z  INFO --------------------------------

2025-09-09T21:58:49.185046Z  INFO TEST 2: weighted_legacy_creation
2025-09-09T21:58:49.862499Z  INFO Starting Tycho
2025-09-09T21:58:51.140681Z  INFO Building protocol cache
2025-09-09T21:58:51.160409Z  INFO populate: ProtocolCachePopulated n_tokens=1 n_components=0 n_prices=0
2025-09-09T21:59:29.875742Z  INFO initialize_accounts: Initializing accounts block_number=13148365 n_accounts=1 block_id=13148365
2025-09-09T21:59:29.912741Z  INFO initialize_accounts: NewContract block_number=13148365 contract_address=Bytes(0xba12222222228d8ba445958a75a0704d566bf2c8) n_accounts=1 block_id=13148365
2025-09-09T21:59:30.105476Z  WARN No cursor found, starting from the beginning name="test_protocol" chain=Ethereum
2025-09-09T21:59:30.302494Z  INFO Extractor ethereum:test_protocol started!
2025-09-09T21:59:30.302626Z  INFO Starting full server
2025-09-09T21:59:30.302686Z  INFO extractor:subscribe: New subscription subscriber_id=0 extractor_id=ethereum:test_protocol
2025-09-09T21:59:30.302903Z  INFO Http and Ws server started server_url="http://0.0.0.0:4242"
2025-09-09T21:59:31.303293Z  INFO extractor: SubstreamSessionInit session.resolved_start_block=13148365 session.linear_handoff_block=13149000 session.max_parallel_workers=10 session.trace_id="943a2a9eaa2ffac7624b33f3da9cefdb" extractor_id=ethereum:test_protocol sf_trace_id="943a2a9eaa2ffac7624b33f3da9cefdb"
2025-09-09T21:59:31.684648Z  INFO extractor:handle_tick_scoped_data: NewContract block_number=13148365 contract_address=Bytes(0xbf96189eee9357a95c7719f4f5047f76bde804e5) extractor_id=ethereum:test_protocol block_number=13148366 block_number=13148366
2025-09-09T21:59:32.671811Z  INFO extractor: Stream completed, reached end block extractor_id=ethereum:test_protocol
2025-09-09T21:59:32.671841Z ERROR extractor: stream ended extractor_id=ethereum:test_protocol

thread 'main' panicked at tycho-indexer/src/main.rs:89:67:
called `Result::unwrap()` on an `Err` value: SubstreamsError("ethereum:test_protocol: stream ended")
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
2025-09-09T21:59:32.699054Z  INFO Upgrading database...
2025-09-09T21:59:32.810284Z  INFO Starting Tycho RPC
2025-09-09T21:59:32.810635Z  INFO Starting standalone rpc server
2025-09-09T21:59:32.813723Z  INFO starting 10 workers
2025-09-09T21:59:32.813776Z  INFO Http and Ws server started server_url="http://0.0.0.0:4242"
2025-09-09T21:59:32.813804Z  INFO Tokio runtime found; starting in existing Tokio runtime
2025-09-09T21:59:35.695227Z  INFO protocol_components:get_protocol_components: Getting protocol components. request=ProtocolComponentsRequestBody { protocol_system: "test_protocol", component_ids: None, tvl_gt: None, chain: Ethereum, pagination: PaginationParams { page: 0, page_size: 100 } } page=0 page_size=100 protocol_system="test_protocol" user_identity="unknown"
2025-09-09T21:59:35.792628Z  WARN get_contract_state: No contract ids specified in request.
2025-09-09T21:59:35.793190Z  INFO contract_state:get_contract_state: Getting contract state. request=StateRequestBody { contract_ids: None, protocol_system: "test_protocol", version: VersionParam { timestamp: Some(2025-09-09T21:59:35.792535), block: None }, chain: Ethereum, pagination: PaginationParams { page: 0, page_size: 100 } } page=0 page_size=100 protocol_system="test_protocol" user_identity="unknown"
2025-09-09T21:59:35.851086Z  INFO Found 1 protocol components
2025-09-09T21:59:35.851108Z  INFO Found 1 protocol states
2025-09-09T21:59:35.851112Z  INFO Validating state...
2025-09-09T21:59:35.851124Z  INFO Component 0xbf96189eee9357a95c7719f4f5047f76bde804e5000200000000000000000087 matches the expected state
2025-09-09T21:59:35.851128Z  INFO All expected components were successfully found on Tycho and match the expected state
2025-09-09T21:59:35.851130Z  INFO Skipping balance check
2025-09-09T21:59:35.851226Z  INFO Found adapter contract at: /Users/tamaralipowski/Code/tycho-protocol-sdk/protocol-testing/../evm/out/BalancerV2SwapAdapter.sol/BalancerV2SwapAdapter.evm.runtime
2025-09-09T21:59:35.851245Z  INFO Using adapter contract: /Users/tamaralipowski/Code/tycho-protocol-sdk/protocol-testing/../evm/out/BalancerV2SwapAdapter.sol/BalancerV2SwapAdapter.evm.runtime
2025-09-09T21:59:35.852184Z  INFO Components to simulate: 1
2025-09-09T21:59:35.852216Z  INFO   Simulating component: 0xbf96189eee9357a95c7719f4f5047f76bde804e5000200000000000000000087
2025-09-09T21:59:35.999419Z  INFO Loading tokens from Tycho...
2025-09-09T21:59:36.021306Z  INFO Loaded 3 tokens
2025-09-09T21:59:36.021549Z  INFO Processing 2 contracts from snapshots
2025-09-09T21:59:36.026029Z  INFO Updating engine with 2 contracts from snapshots
2025-09-09T21:59:36.052824Z  INFO Engine updated
2025-09-09T21:59:36.064610Z  INFO Decoded 1 snapshots for protocol test_protocol
2025-09-09T21:59:36.065083Z  INFO Amount out for 0xbf96189eee9357a95c7719f4f5047f76bde804e5000200000000000000000087: calculating for tokens "LDO/WETH"
2025-09-09T21:59:36.065160Z  INFO Spot price "LDO/WETH": 0.001283639349665904
2025-09-09T21:59:36.066477Z  INFO Retrieved limits. | Max input: 18511402922201617603 LDO | Max output: 6000000000000000 WETH
2025-09-09T21:59:36.072813Z  INFO Amount out for trading 0.1% of max: (18511402922201617 LDO -> 23922100600891 WETH) (gas: 114936)
2025-09-09T21:59:36.079669Z  INFO Amount out for trading 1.0% of max: (185114029222016176 LDO -> 237619652084584 WETH) (gas: 114936)
2025-09-09T21:59:36.085869Z  INFO Amount out for trading 10.0% of max: (1851140292220161760 LDO -> 2225082446672723 WETH) (gas: 114936)
2025-09-09T21:59:36.086995Z  INFO Retrieved limits. | Max input: 6000000000000000 WETH | Max output: 18511402922201617603 LDO
2025-09-09T21:59:36.092925Z  INFO Amount out for trading 0.1% of max: (6000000000000 WETH -> 4615417908011445 LDO) (gas: 114967)
2025-09-09T21:59:36.098406Z  INFO Amount out for trading 1.0% of max: (60000000000000 WETH -> 46076665460980030 LDO) (gas: 114967)
2025-09-09T21:59:36.103509Z  INFO Amount out for trading 10.0% of max: (600000000000000 WETH -> 453183404234049961 LDO) (gas: 114967)
2025-09-09T21:59:36.103532Z  INFO 
✅ Simulation validation passed.

2025-09-09T21:59:36.105321Z  INFO 
✅ weighted_legacy_creation passed.

```