### PR TITLE
feat: update balancer v2 spkg to make it return old slot values

### DIFF
--- a/substreams/Cargo.lock
+++ b/substreams/Cargo.lock
@@ -250,7 +250,7 @@ dependencies = [
  "num-bigint",
  "substreams",
  "substreams-ethereum",
- "tycho-substreams 0.5.0 (git+https://github.com/propeller-heads/tycho-protocol-sdk.git?tag=0.5.0)",
+ "tycho-substreams 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1777,7 +1777,8 @@ dependencies = [
 [[package]]
 name = "tycho-substreams"
 version = "0.5.0"
-source = "git+https://github.com/propeller-heads/tycho-protocol-sdk.git?tag=0.5.0#655fae77aba34b84353d923575096bd9c26ee418"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "828cbe6f7b984fefe39d8fdb4c40311e329f30ded0a70e477e8f2add4d60483d"
 dependencies = [
  "ethabi 18.0.0",
  "hex",

--- a/substreams/Cargo.lock
+++ b/substreams/Cargo.lock
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "ethereum-balancer-v2"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "ethabi 18.0.0",
@@ -250,7 +250,7 @@ dependencies = [
  "num-bigint",
  "substreams",
  "substreams-ethereum",
- "tycho-substreams 0.2.2",
+ "tycho-substreams 0.5.0 (git+https://github.com/propeller-heads/tycho-protocol-sdk.git?tag=0.5.0)",
 ]
 
 [[package]]
@@ -1768,6 +1768,22 @@ dependencies = [
  "num-bigint",
  "prost 0.11.9",
  "rstest",
+ "serde",
+ "serde_json",
+ "substreams",
+ "substreams-ethereum",
+]
+
+[[package]]
+name = "tycho-substreams"
+version = "0.5.0"
+source = "git+https://github.com/propeller-heads/tycho-protocol-sdk.git?tag=0.5.0#655fae77aba34b84353d923575096bd9c26ee418"
+dependencies = [
+ "ethabi 18.0.0",
+ "hex",
+ "itertools 0.12.1",
+ "num-bigint",
+ "prost 0.11.9",
  "serde",
  "serde_json",
  "substreams",

--- a/substreams/ethereum-balancer-v2/Cargo.toml
+++ b/substreams/ethereum-balancer-v2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum-balancer-v2"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2021"
 
 [lib]
@@ -15,7 +15,7 @@ hex = "0.4.3"
 anyhow = "1.0.75"
 num-bigint = "0.4.4"
 itertools = "0.12.0"
-tycho-substreams = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", tag = "0.4.0" }
+tycho-substreams = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", tag = "0.5.0" }
 
 [build-dependencies]
 anyhow = "1"

--- a/substreams/ethereum-balancer-v2/Cargo.toml
+++ b/substreams/ethereum-balancer-v2/Cargo.toml
@@ -15,7 +15,7 @@ hex = "0.4.3"
 anyhow = "1.0.75"
 num-bigint = "0.4.4"
 itertools = "0.12.0"
-tycho-substreams = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", tag = "0.5.0" }
+tycho-substreams = "0.5.0"
 
 [build-dependencies]
 anyhow = "1"

--- a/substreams/ethereum-balancer-v2/substreams.yaml
+++ b/substreams/ethereum-balancer-v2/substreams.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: "ethereum_balancer_v2"
-  version: v0.3.2
+  version: v0.4.0
   url: "https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/substreams/ethereum-balancer-v2"
 
 protobuf:


### PR DESCRIPTION
This is needed for the new DCI version that uses old values to look into exactly what part of the slot change and compare with the retrigger offset