### PR TITLE
fix: Fix python tests

### DIFF
--- a/substreams/ethereum-balancer-v3/integration_test.tycho.yaml
+++ b/substreams/ethereum-balancer-v3/integration_test.tycho.yaml
@@ -1,4 +1,5 @@
 substreams_yaml_path: ./substreams.yaml
+protocol_system: "vm:balancer_v3"
 protocol_type_names:
   - "balancer_v3_pool"
 adapter_contract: "BalancerV3SwapAdapter"

--- a/substreams/ethereum-balancer-v3/substreams.yaml
+++ b/substreams/ethereum-balancer-v3/substreams.yaml
@@ -10,9 +10,6 @@ protobuf:
     - tycho/evm/v1/utils.proto
   importPaths:
     - ../../proto
-  excludePaths:
-    - sf/substreams
-    - google
 
 binaries:
   default:

--- a/testing/src/runner/tycho.py
+++ b/testing/src/runner/tycho.py
@@ -59,6 +59,7 @@ class TychoRunner:
         end_block: int,
         protocol_type_names: list,
         initialized_accounts: list,
+        protocol_system: str = "test_protocol",
     ) -> None:
         """Run the Tycho indexer with the specified SPKG and block range."""
 
@@ -80,6 +81,8 @@ class TychoRunner:
                     "map_protocol_changes",
                     "--protocol-type-names",
                     ",".join(protocol_type_names),
+                    "--protocol-system",
+                    protocol_system,
                     "--start-block",
                     str(start_block),
                     "--stop-block",


### PR DESCRIPTION
- These are just used for comparison purposes and will eventually be deleted.
- Also balancer v3 test fix: add protocol_system to yaml, and remove "excludePaths" from protobuf in substreams.yaml (this entry was not supported)