### PR TITLE
fix: remove break-lines from "Get changed substreams folders" step output

### DIFF
--- a/.github/workflows/substreams.tests.yaml
+++ b/.github/workflows/substreams.tests.yaml
@@ -59,7 +59,7 @@ jobs:
         run: |
           CHANGED=$(git diff --name-only origin/main ${{ github.sha }} | \
             grep '^substreams/' | awk -F'/' '{print $2}' | sort -u | \
-            grep -v -E "^(${EXCLUDED_SUBSTREAMS})$")
+            grep -v -E "^(${EXCLUDED_SUBSTREAMS})$" | tr '\n' ' ' | sed 's/ *$//')
           if [ -z "$CHANGED" ]; then
               echo "No changed substreams"
           else


### PR DESCRIPTION
When multiple changes were detected, each one was written in a separate line, causing an error on github actions ([error example](https://github.com/propeller-heads/tycho-protocol-sdk/actions/runs/17813600358/job/50642522219?pr=269#step:7:21))