### PR TITLE
fix: build runtime cmd

### DIFF
--- a/testing/src/runner/adapter_builder.py
+++ b/testing/src/runner/adapter_builder.py
@@ -46,7 +46,7 @@ class AdapterContractBuilder:
         try:
             # Running the bash script with the provided arguments
             result = subprocess.run(
-                [script_path, "-c", adapter_contract, "-s", signature, "-a", args],
+                cmd,
                 cwd=self.src_path,
                 capture_output=True,
                 text=True,


### PR DESCRIPTION
We’re building the `cmd` here, but it’s not actually used. If `signature` or `args` is None, it’ll fail.