### PR TITLE
fix: update `get_block_storage_changes` to correctly emit previous value

### DIFF
--- a/substreams/Cargo.lock
+++ b/substreams/Cargo.lock
@@ -250,7 +250,7 @@ dependencies = [
  "num-bigint",
  "substreams",
  "substreams-ethereum",
- "tycho-substreams 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tycho-substreams 0.5.0",
 ]
 
 [[package]]
@@ -1761,22 +1761,6 @@ dependencies = [
 [[package]]
 name = "tycho-substreams"
 version = "0.5.0"
-dependencies = [
- "ethabi 18.0.0",
- "hex",
- "itertools 0.12.1",
- "num-bigint",
- "prost 0.11.9",
- "rstest",
- "serde",
- "serde_json",
- "substreams",
- "substreams-ethereum",
-]
-
-[[package]]
-name = "tycho-substreams"
-version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "828cbe6f7b984fefe39d8fdb4c40311e329f30ded0a70e477e8f2add4d60483d"
 dependencies = [
@@ -1785,6 +1769,22 @@ dependencies = [
  "itertools 0.12.1",
  "num-bigint",
  "prost 0.11.9",
+ "serde",
+ "serde_json",
+ "substreams",
+ "substreams-ethereum",
+]
+
+[[package]]
+name = "tycho-substreams"
+version = "0.5.1"
+dependencies = [
+ "ethabi 18.0.0",
+ "hex",
+ "itertools 0.12.1",
+ "num-bigint",
+ "prost 0.11.9",
+ "rstest",
  "serde",
  "serde_json",
  "substreams",

--- a/substreams/crates/tycho-substreams/Cargo.toml
+++ b/substreams/crates/tycho-substreams/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tycho-substreams"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 description = "Tycho substreams development kit, contains tycho-indexer block changes model and helper functions for common indexing tasks."
 repository = "https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/substreams/crates/tycho-substreams"

--- a/substreams/crates/tycho-substreams/src/block_storage.rs
+++ b/substreams/crates/tycho-substreams/src/block_storage.rs
@@ -54,14 +54,18 @@ pub fn get_block_storage_changes(block: &eth::v2::Block) -> Vec<TransactionStora
                 // Collect latest change per slot
                 let mut latest_changes: HashMap<Vec<u8>, ContractSlot> = HashMap::new();
                 for change in changes {
-                    latest_changes.insert(
-                        change.key.clone(),
-                        ContractSlot {
+                    latest_changes
+                        .entry(change.key.clone())
+                        .and_modify(|slot| {
+                            // Only update the latest value, previous value stays the first seen
+                            // one.
+                            slot.value = change.new_value.clone();
+                        })
+                        .or_insert(ContractSlot {
                             slot: change.key,
                             value: change.new_value,
                             previous_value: change.old_value,
-                        },
-                    );
+                        });
                 }
 
                 StorageChanges { address, slots: latest_changes.into_values().collect() }


### PR DESCRIPTION
Before this PR we were using the latest `ContractSlot` for both previous and new value. This is not correct because if the value changed twice we would have the middle value emitted as "previous". For example if a value was changed like this in a single transaction 1 -> 10 -> 2 we would have `new_value=2` and `previous_values=10` while the previous value was actually 1.