### PR TITLE
feat: PancakeswapV3 test 

### DIFF
--- a/substreams/ethereum-pancakeswap-v3/integration_test.tycho.yaml
+++ b/substreams/ethereum-pancakeswap-v3/integration_test.tycho.yaml
@@ -1,0 +1,21 @@
+substreams_yaml_path: ./ethereum-pancakeswap-v3.yaml
+protocol_system: "pancakeswap_v3"
+protocol_type_names:
+  - "pancakeswap_v3_pool"
+module_name: "map_protocol_changes"
+skip_balance_check: false
+initialized_accounts:
+tests:
+  - name: test_usdt_usdf_pool
+    start_block: 22187893
+    stop_block: 22187895
+    expected_components:
+      - id: "0x0d9ea0d5e3f400b1df8f695be04292308c041e77"
+        tokens:
+          - "0xfa2b947eec368f42195f24f36d2af29f7c24cec2" # USDf
+          - "0xdac17f958d2ee523a2206206994597c13d831ec7" # USDT
+        static_attributes:
+          fee: "0x64"
+        creation_tx: "0x87a9c643b0836ee7e7d7863d4f4d97310d14c438cb49bc8771c3d7a9d5a2749f"
+        skip_simulation: false
+        skip_execution: true


### PR DESCRIPTION
- There are only two post-cancun PancakeV3 pools.
- One was ORDER-WETH which I guess had a liquidity issue, it failed with `StateDecodingFailure pool="0xb2dc4d7627501338b578985c214208eb32283086" error=Missing attributes tick_liquidities`
This is raised here in the UniswapV3 decoder:
```
        let mut ticks = match ticks {
            Ok(ticks) if !ticks.is_empty() => ticks
                .into_iter()
                .filter(|t| t.net_liquidity != 0)
                .collect::<Vec<_>>(),
            _ => return Err(InvalidSnapshotError::MissingAttribute("tick_liquidities".to_string())),
        };
 ```

- The second post-cancun pool is this USDT-USDf pool used for this test, though we fail to detect the balance slot of USDT: `WrongSlotError(“Slot override didn’t change balance.“)`

About the balance slot detection error... this was Claude's insight
```
  The detector probably finds a slot that's read during balanceOf() but isn't the actual balance storage slot. For example:
  - It might detect a slot used for pause checks
  - Or a slot used for blacklist verification
  - Or total supply reads that happen during execution
```
 We could overcome this by hardcoding the USDT balance slot, but not sure it's worth it.
 
 
- For this reason, we skip execution.
- Also includes stop_block fix (better explained in Uniswap V2 test PR)