### PR TITLE
fix: UniswapV2 test - use post-cancun created pool

### DIFF
--- a/protocol-testing/src/test_runner.rs
+++ b/protocol-testing/src/test_runner.rs
@@ -267,7 +267,7 @@ impl TestRunner {
                 self.validate_token_balances(
                     &component_tokens,
                     &response_protocol_states_by_id,
-                    test.start_block,
+                    test.stop_block,
                 )?;
                 info!("All token balances match the values found onchain")
             }
@@ -772,7 +772,7 @@ impl TestRunner {
         &self,
         component_tokens: &HashMap<String, Vec<Token>>,
         protocol_states_by_id: &HashMap<String, ResponseProtocolState>,
-        start_block: u64,
+        stop_block: u64,
     ) -> miette::Result<()> {
         for (id, component) in protocol_states_by_id.iter() {
             let tokens = component_tokens.get(id);
@@ -797,12 +797,11 @@ impl TestRunner {
                             .block_on(self.rpc_provider.get_token_balance(
                                 token_address,
                                 component_address,
-                                start_block,
+                                stop_block,
                             ))?;
                     if balance != node_balance {
                         return Err(miette!(
-                            "Token balance mismatch for component {} and token {}",
-                            id,
+                            "Token balance mismatch for component {id} and token {}. Balance: {balance}, Node balance: {node_balance}",
                             token.symbol
                         ));
                     }

--- a/substreams/ethereum-uniswap-v2/integration_test.tycho.yaml
+++ b/substreams/ethereum-uniswap-v2/integration_test.tycho.yaml
@@ -3,18 +3,18 @@ protocol_system: "uniswap_v2"
 protocol_type_names:
   - "uniswap_v2_pool"
 module_name: "map_pool_events"
-skip_balance_check: true
+skip_balance_check: false
 initialized_accounts:
 tests:
-  - name: test_spx_weth_pool
-    start_block: 17924533
-    stop_block: 17924534
+  - name: test_wolf_weth_pool
+    start_block: 19701395
+    stop_block: 19701397
     expected_components:
-      - id: "0x52c77b0CB827aFbAD022E6d6CAF2C44452eDbc39"
+      - id: "0x67324985b5014b36b960273353deb3d96f2f18c2"
         tokens:
-          - "0xe0f63a424a4439cbe457d80e4f4b51ad25b2c56c"
+          - "0x67466BE17df832165F8C80a5A120CCc652bD7E69"
           - "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
         static_attributes:
           fee: "0x1e"
-        creation_tx: "0xf09ac8ad7e21d15ded627a176ec718903baae5e5a9ce671a611bd852691b24f9"
+        creation_tx: "0x5e01ae1522722340871708a3c55e1395dda647a57767781230317319fa36ea7b"
         skip_simulation: false


### PR DESCRIPTION
- Also fix balance check: this should use the stop block not start block, since the start block is before the component was even created.