### PR TITLE
ci: correctly report `test-changed` even if nothing changed

### DIFF
--- a/.github/workflows/substreams.tests.yaml
+++ b/.github/workflows/substreams.tests.yaml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
-      - 'substreams/**'
+      - "substreams/**"
 
 jobs:
   detect-changes:
@@ -70,13 +70,33 @@ jobs:
   test-changed:
     runs-on: ubuntu-latest
     needs: [detect-changes]
-    if: needs.detect-changes.outputs.substreams-changed == 'true' && needs.detect-changes.outputs.changed-substreams != ''
     steps:
+      - name: Check if tests are needed
+        id: should-test
+        run: |
+          SUBSTREAMS_CHANGED="${{ needs.detect-changes.outputs.substreams-changed }}"
+          CHANGED_SUBSTREAMS="${{ needs.detect-changes.outputs.changed-substreams }}"
+
+          if [[ "$SUBSTREAMS_CHANGED" == "true" && -n "$CHANGED_SUBSTREAMS" ]]; then
+            echo "should_run=true" >> $GITHUB_OUTPUT
+            echo "protocols=$CHANGED_SUBSTREAMS" >> $GITHUB_OUTPUT
+          else
+            echo "should_run=false" >> $GITHUB_OUTPUT
+            echo "No substreams changes detected - skipping tests"
+          fi
+
       - uses: actions/checkout@v4
+        if: steps.should-test.outputs.should_run == 'true'
+
       - name: Run tests for changed substreams
+        if: steps.should-test.outputs.should_run == 'true'
         uses: ./.github/actions/substreams-docker
         with:
-          protocols: ${{ needs.detect-changes.outputs.changed-substreams }}
+          protocols: ${{ steps.should-test.outputs.protocols }}
+
+      - name: Skip tests
+        if: steps.should-test.outputs.should_run != 'true'
+        run: echo "✓ No changes detected - skipping tests"
 
   test-all:
     runs-on: ubuntu-latest


### PR DESCRIPTION
`test-changed` is enforced on every merge to main, so we need it to report even if there is nothing to test