### PR TITLE
feat: update entrypoint creation requirements

### DIFF
--- a/proto/tycho/evm/v1/common.proto
+++ b/proto/tycho/evm/v1/common.proto
@@ -169,9 +169,9 @@ message EntryPoint {
 message EntryPointParams {
   // The entrypoint id.
   string entrypoint_id = 1;
-  // [optional] The component that uses these entrypoint parameters. Currently used for debugging purposes only.
+  // The component that uses these entrypoint parameters. This field is now required (optional support is deprecated).
   optional string component_id = 2;
-  // The strategy and its corresponding data
+  // The strategy and its corresponding data.
   oneof trace_data {
     RPCTraceData rpc = 3;
     // Add more strategies here
@@ -182,17 +182,17 @@ message EntryPointParams {
 message RPCTraceData {
   // [optional] The caller to be used for the trace. If none is provided a chain default will be used.
   optional bytes caller = 1;
-  // The calldata to be used for the trace
+  // The calldata to be used for the trace.
   bytes calldata = 2;
 }
 
 // A contract and associated storage changes
 message StorageChanges {
-  // The contract's address
+  // The contract's address.
   bytes address = 1;
-  // The contract's storage changes
+  // The contract's storage changes.
   repeated ContractSlot slots = 2;
-  // [optional] The contract's balance change
+  // [optional] The contract's balance change.
   optional bytes native_balance = 3;
 }
 

--- a/substreams/Cargo.lock
+++ b/substreams/Cargo.lock
@@ -563,7 +563,7 @@ dependencies = [
  "substreams-ethereum",
  "substreams-helper 0.0.2 (git+https://github.com/propeller-heads/tycho-protocol-sdk.git?tag=0.5.0)",
  "tiny-keccak",
- "tycho-substreams 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tycho-substreams 0.6.0",
 ]
 
 [[package]]
@@ -584,7 +584,7 @@ dependencies = [
  "substreams-ethereum",
  "substreams-helper 0.0.2 (git+https://github.com/propeller-heads/tycho-protocol-sdk.git?tag=0.5.0)",
  "tiny-keccak",
- "tycho-substreams 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tycho-substreams 0.6.0",
 ]
 
 [[package]]
@@ -606,7 +606,7 @@ dependencies = [
  "substreams-ethereum",
  "substreams-helper 0.0.2 (git+https://github.com/propeller-heads/tycho-protocol-sdk.git?tag=0.5.0)",
  "tiny-keccak",
- "tycho-substreams 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tycho-substreams 0.6.0",
 ]
 
 [[package]]
@@ -1889,23 +1889,6 @@ dependencies = [
 [[package]]
 name = "tycho-substreams"
 version = "0.6.0"
-dependencies = [
- "base64 0.22.1",
- "ethabi 18.0.0",
- "hex",
- "itertools 0.12.1",
- "num-bigint",
- "prost 0.11.9",
- "rstest",
- "serde",
- "serde_json",
- "substreams",
- "substreams-ethereum",
-]
-
-[[package]]
-name = "tycho-substreams"
-version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6381b4b9443e767339412f1fdfc8a2dff208563ba8901d9b5181ac148b6064b"
 dependencies = [
@@ -1914,6 +1897,23 @@ dependencies = [
  "itertools 0.12.1",
  "num-bigint",
  "prost 0.11.9",
+ "serde",
+ "serde_json",
+ "substreams",
+ "substreams-ethereum",
+]
+
+[[package]]
+name = "tycho-substreams"
+version = "0.7.0"
+dependencies = [
+ "base64 0.22.1",
+ "ethabi 18.0.0",
+ "hex",
+ "itertools 0.12.1",
+ "num-bigint",
+ "prost 0.11.9",
+ "rstest",
  "serde",
  "serde_json",
  "substreams",

--- a/substreams/crates/tycho-substreams/Cargo.toml
+++ b/substreams/crates/tycho-substreams/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tycho-substreams"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "Tycho substreams development kit, contains tycho-indexer block changes model and helper functions for common indexing tasks."
 repository = "https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/substreams/crates/tycho-substreams"

--- a/substreams/crates/tycho-substreams/src/entrypoint.rs
+++ b/substreams/crates/tycho-substreams/src/entrypoint.rs
@@ -6,6 +6,18 @@ fn get_entrypoint_id(target: &[u8], signature: &str) -> String {
 }
 
 /// Creates an entrypoint and its parameters.
+///
+/// These are used by the Dynamic Contract Indexer (DCI) to dynamically trace contract calls and
+/// index relevant code and storage.
+///
+/// # Parameters
+/// - `target`: The target contract to analyse this entrypoint on.
+/// - `signature`: The signature of the function to analyse.
+/// - `component_id`: The id of the component that uses this entrypoint.
+/// - `trace_data`: The trace data to be used to trace the entrypoint.
+///
+/// # Returns
+/// - `(EntryPoint, EntryPointParams)`: A tuple containing the entrypoint and parameter messages.
 pub fn create_entrypoint(
     target: Vec<u8>,
     signature: String,
@@ -25,28 +37,4 @@ pub fn create_entrypoint(
         trace_data: Some(trace_data),
     };
     (entrypoint, entrypoint_params)
-}
-
-// Adds EntryPointParams associated with an already existing Entrypoint.
-pub fn add_entrypoint_params(
-    target: Vec<u8>,
-    signature: String,
-    trace_data: TraceData,
-    component_id: Option<String>,
-) -> EntryPointParams {
-    EntryPointParams {
-        entrypoint_id: get_entrypoint_id(&target, &signature),
-        component_id,
-        trace_data: Some(trace_data),
-    }
-}
-
-// Adds a component to an existing Entrypoint.
-pub fn add_component_to_entrypoint(
-    target: Vec<u8>,
-    signature: String,
-    component_id: String,
-) -> EntryPoint {
-    let entrypoint_id = get_entrypoint_id(&target, &signature);
-    EntryPoint { id: entrypoint_id, target, signature, component_id }
 }

--- a/substreams/crates/tycho-substreams/src/pb/tycho.evm.v1.rs
+++ b/substreams/crates/tycho-substreams/src/pb/tycho.evm.v1.rs
@@ -204,16 +204,16 @@ pub struct EntryPointParams {
     /// The entrypoint id.
     #[prost(string, tag="1")]
     pub entrypoint_id: ::prost::alloc::string::String,
-    /// \[optional\] The component that uses these entrypoint parameters. Currently used for debugging purposes only.
+    /// The component that uses these entrypoint parameters. This field is now required (optional support is deprecated).
     #[prost(string, optional, tag="2")]
     pub component_id: ::core::option::Option<::prost::alloc::string::String>,
-    /// The strategy and its corresponding data
+    /// The strategy and its corresponding data.
     #[prost(oneof="entry_point_params::TraceData", tags="3")]
     pub trace_data: ::core::option::Option<entry_point_params::TraceData>,
 }
 /// Nested message and enum types in `EntryPointParams`.
 pub mod entry_point_params {
-    /// The strategy and its corresponding data
+    /// The strategy and its corresponding data.
     #[derive(Eq, Hash)]
     #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Oneof)]
@@ -231,7 +231,7 @@ pub struct RpcTraceData {
     /// \[optional\] The caller to be used for the trace. If none is provided a chain default will be used.
     #[prost(bytes="vec", optional, tag="1")]
     pub caller: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
-    /// The calldata to be used for the trace
+    /// The calldata to be used for the trace.
     #[prost(bytes="vec", tag="2")]
     pub calldata: ::prost::alloc::vec::Vec<u8>,
 }
@@ -239,13 +239,13 @@ pub struct RpcTraceData {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StorageChanges {
-    /// The contract's address
+    /// The contract's address.
     #[prost(bytes="vec", tag="1")]
     pub address: ::prost::alloc::vec::Vec<u8>,
-    /// The contract's storage changes
+    /// The contract's storage changes.
     #[prost(message, repeated, tag="2")]
     pub slots: ::prost::alloc::vec::Vec<ContractSlot>,
-    /// \[optional\] The contract's balance change
+    /// \[optional\] The contract's balance change.
     #[prost(bytes="vec", optional, tag="3")]
     pub native_balance: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
 }


### PR DESCRIPTION
Make component link to created entrypoint/params required. This is needed for the indexer's DCI logic (particularly the auto-retracing feature).