### PR TITLE
ci: Get ETH_RPC_URL from the org secrets in the main workflow

### DIFF
--- a/.github/actions/substreams-docker/action.yml
+++ b/.github/actions/substreams-docker/action.yml
@@ -41,7 +41,7 @@ runs:
     - name: Run protocol tests
       env:
         PROTOCOLS: ${{ inputs.protocols }}
-        RPC_URL: ${{ secrets.ETH_RPC_URL }}
+        RPC_URL: ${{ env.RPC_URL }}
         SUBSTREAMS_API_TOKEN: ${{ env.SUBSTREAMS_API_TOKEN }}
       run: |
         docker compose up --abort-on-container-exit --exit-code-from test-runner

--- a/.github/workflows/substreams.tests.yaml
+++ b/.github/workflows/substreams.tests.yaml
@@ -1,7 +1,7 @@
 name: Substreams Tests
 
 env:
-  RPC_URL: ${{ secrets.RPC_URL }}
+  RPC_URL: ${{ secrets.ETH_RPC_URL }}
   SUBSTREAMS_API_TOKEN: ${{ secrets.SUBSTREAMS_API_TOKEN }}
   AUTH_API_KEY: ${{ secrets.AUTH_API_KEY }}
   EXCLUDED_SUBSTREAMS: target|crates|ethereum-template-factory|ethereum-template-singleton


### PR DESCRIPTION
Composite actions can't access secrets directly