### PR TITLE
Add Arbitrum substreams YAML configs for UniswapV4 and PancakeSwapV3

### DIFF
--- a/substreams/ethereum-pancakeswap-v3/arbitrum-pancakeswap-v3.yaml
+++ b/substreams/ethereum-pancakeswap-v3/arbitrum-pancakeswap-v3.yaml
@@ -1,0 +1,124 @@
+specVersion: v0.1.0
+package:
+  name: "arbitrum_pancakeswap_v3"
+  version: v0.1.2
+
+protobuf:
+  files:
+    - tycho/evm/v1/common.proto
+    - tycho/evm/v1/utils.proto
+    - pancakeswap.proto
+  importPaths:
+    - ./proto/v1
+    - ../../proto/
+
+binaries:
+  default:
+    type: wasm/rust-v1
+    file: ../target/wasm32-unknown-unknown/release/ethereum_pancakeswap_v3.wasm
+
+modules:
+  - name: map_pools_created
+    kind: map
+    initialBlock: 119957974
+    inputs:
+      - params: string
+      - source: sf.ethereum.type.v2.Block
+    output:
+      type: proto:tycho.evm.v1.BlockChanges
+
+  - name: store_pools
+    kind: store
+    initialBlock: 119957974
+    updatePolicy: set_if_not_exists
+    valueType: proto:pancakeswap.v3.Pool
+    inputs:
+      - map: map_pools_created
+
+  - name: map_events
+    kind: map
+    initialBlock: 119957974
+    inputs:
+      - source: sf.ethereum.type.v2.Block
+      - store: store_pools
+    output:
+      type: proto:pancakeswap.v3.Events
+
+  - name: map_balance_changes
+    kind: map
+    initialBlock: 119957974
+    inputs:
+      - map: map_events
+    output:
+      type: proto:tycho.evm.v1.BlockBalanceDeltas
+
+  - name: store_pools_balances
+    kind: store
+    initialBlock: 119957974
+    updatePolicy: add
+    valueType: bigint
+    inputs:
+      - map: map_balance_changes
+
+  - name: map_ticks_changes
+    kind: map
+    initialBlock: 119957974
+    inputs:
+      - map: map_events
+    output:
+      type: proto:pancakeswap.v3.TickDeltas
+
+  - name: store_ticks_liquidity
+    kind: store
+    initialBlock: 119957974
+    updatePolicy: add
+    valueType: bigint
+    inputs:
+      - map: map_ticks_changes
+
+  - name: store_pool_current_tick
+    kind: store
+    initialBlock: 119957974
+    updatePolicy: set
+    valueType: int64
+    inputs:
+      - map: map_events
+
+  - name: map_liquidity_changes
+    kind: map
+    initialBlock: 119957974
+    inputs:
+      - map: map_events
+      - store: store_pool_current_tick
+    output:
+      type: proto:pancakeswap.v3.LiquidityChanges
+
+  - name: store_liquidity
+    kind: store
+    initialBlock: 119957974
+    updatePolicy: set_sum
+    valueType: bigint
+    inputs:
+      - map: map_liquidity_changes
+
+  - name: map_protocol_changes
+    kind: map
+    initialBlock: 119957974
+    inputs:
+      - source: sf.ethereum.type.v2.Block
+      - map: map_pools_created
+      - map: map_events
+      - map: map_balance_changes
+      - store: store_pools_balances
+        mode: deltas
+      - map: map_ticks_changes
+      - store: store_ticks_liquidity
+        mode: deltas
+      - map: map_liquidity_changes
+      - store: store_liquidity
+        mode: deltas
+    output:
+      type: proto:tycho.evm.v1.BlockChanges
+
+params:
+  map_pools_created: "0BFbCF9fa4f9C56B0F40a671Ad40E0805A091865"

--- a/substreams/ethereum-pancakeswap-v3/arbitrum-pancakeswap-v3.yaml
+++ b/substreams/ethereum-pancakeswap-v3/arbitrum-pancakeswap-v3.yaml
@@ -20,7 +20,7 @@ binaries:
 modules:
   - name: map_pools_created
     kind: map
-    initialBlock: 119957974
+    initialBlock: 101028949
     inputs:
       - params: string
       - source: sf.ethereum.type.v2.Block
@@ -29,7 +29,7 @@ modules:
 
   - name: store_pools
     kind: store
-    initialBlock: 119957974
+    initialBlock: 101028949
     updatePolicy: set_if_not_exists
     valueType: proto:pancakeswap.v3.Pool
     inputs:
@@ -37,7 +37,7 @@ modules:
 
   - name: map_events
     kind: map
-    initialBlock: 119957974
+    initialBlock: 101028949
     inputs:
       - source: sf.ethereum.type.v2.Block
       - store: store_pools
@@ -46,7 +46,7 @@ modules:
 
   - name: map_balance_changes
     kind: map
-    initialBlock: 119957974
+    initialBlock: 101028949
     inputs:
       - map: map_events
     output:
@@ -54,7 +54,7 @@ modules:
 
   - name: store_pools_balances
     kind: store
-    initialBlock: 119957974
+    initialBlock: 101028949
     updatePolicy: add
     valueType: bigint
     inputs:
@@ -62,7 +62,7 @@ modules:
 
   - name: map_ticks_changes
     kind: map
-    initialBlock: 119957974
+    initialBlock: 101028949
     inputs:
       - map: map_events
     output:
@@ -70,7 +70,7 @@ modules:
 
   - name: store_ticks_liquidity
     kind: store
-    initialBlock: 119957974
+    initialBlock: 101028949
     updatePolicy: add
     valueType: bigint
     inputs:
@@ -78,7 +78,7 @@ modules:
 
   - name: store_pool_current_tick
     kind: store
-    initialBlock: 119957974
+    initialBlock: 101028949
     updatePolicy: set
     valueType: int64
     inputs:
@@ -86,7 +86,7 @@ modules:
 
   - name: map_liquidity_changes
     kind: map
-    initialBlock: 119957974
+    initialBlock: 101028949
     inputs:
       - map: map_events
       - store: store_pool_current_tick
@@ -95,7 +95,7 @@ modules:
 
   - name: store_liquidity
     kind: store
-    initialBlock: 119957974
+    initialBlock: 101028949
     updatePolicy: set_sum
     valueType: bigint
     inputs:
@@ -103,7 +103,7 @@ modules:
 
   - name: map_protocol_changes
     kind: map
-    initialBlock: 119957974
+    initialBlock: 101028949
     inputs:
       - source: sf.ethereum.type.v2.Block
       - map: map_pools_created

--- a/substreams/ethereum-uniswap-v2/arbitrum-uniswap-v2.yaml
+++ b/substreams/ethereum-uniswap-v2/arbitrum-uniswap-v2.yaml
@@ -6,9 +6,11 @@ package:
 
 protobuf:
   files:
+    - tycho/evm/v1/common.proto
     - uniswap.proto
   importPaths:
     - ./proto/v1
+    - ../../proto/
 
 binaries:
   default:

--- a/substreams/ethereum-uniswap-v3-logs-only/arbitrum-uniswap-v3.yaml
+++ b/substreams/ethereum-uniswap-v3-logs-only/arbitrum-uniswap-v3.yaml
@@ -1,0 +1,128 @@
+specVersion: v0.1.0
+package:
+  name: "arbitrum_uniswap_v3_logs_only"
+  version: v0.1.2
+  url: "https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/substreams/ethereum-uniswap-v3-logs-only"
+
+protobuf:
+  files:
+    - tycho/evm/v1/common.proto
+    - tycho/evm/v1/utils.proto
+    - uniswap.proto
+  importPaths:
+    - ./proto/v1
+    - ../../proto/
+  excludePaths:
+    - sf/ethereum
+    - google
+
+binaries:
+  default:
+    type: wasm/rust-v1
+    file: ../target/wasm32-unknown-unknown/release/ethereum_uniswap_v3_logs_only.wasm
+
+modules:
+  - name: map_pools_created
+    kind: map
+    initialBlock: 37418321
+    inputs:
+      - params: string
+      - source: sf.ethereum.type.v2.Block
+    output:
+      type: proto:tycho.evm.v1.BlockChanges
+
+  - name: store_pools
+    kind: store
+    initialBlock: 37418321
+    updatePolicy: set_if_not_exists
+    valueType: proto:uniswap.v3.Pool
+    inputs:
+      - map: map_pools_created
+
+  - name: map_events
+    kind: map
+    initialBlock: 37418321
+    inputs:
+      - source: sf.ethereum.type.v2.Block
+      - store: store_pools
+    output:
+      type: proto:uniswap.v3.Events
+
+  - name: map_balance_changes
+    kind: map
+    initialBlock: 37418321
+    inputs:
+      - map: map_events
+    output:
+      type: proto:tycho.evm.v1.BlockBalanceDeltas
+
+  - name: store_pools_balances
+    kind: store
+    initialBlock: 37418321
+    updatePolicy: add
+    valueType: bigint
+    inputs:
+      - map: map_balance_changes
+
+  - name: map_ticks_changes
+    kind: map
+    initialBlock: 37418321
+    inputs:
+      - map: map_events
+    output:
+      type: proto:uniswap.v3.TickDeltas
+
+  - name: store_ticks_liquidity
+    kind: store
+    initialBlock: 37418321
+    updatePolicy: add
+    valueType: bigint
+    inputs:
+      - map: map_ticks_changes
+
+  - name: store_pool_current_tick
+    kind: store
+    initialBlock: 37418321
+    updatePolicy: set
+    valueType: int64
+    inputs:
+      - map: map_events
+
+  - name: map_liquidity_changes
+    kind: map
+    initialBlock: 37418321
+    inputs:
+      - map: map_events
+      - store: store_pool_current_tick
+    output:
+      type: proto:uniswap.v3.LiquidityChanges
+
+  - name: store_liquidity
+    kind: store
+    initialBlock: 37418321
+    updatePolicy: set_sum
+    valueType: bigint
+    inputs:
+      - map: map_liquidity_changes
+
+  - name: map_protocol_changes
+    kind: map
+    initialBlock: 37418321
+    inputs:
+      - source: sf.ethereum.type.v2.Block
+      - map: map_pools_created
+      - map: map_events
+      - map: map_balance_changes
+      - store: store_pools_balances
+        mode: deltas
+      - map: map_ticks_changes
+      - store: store_ticks_liquidity
+        mode: deltas
+      - map: map_liquidity_changes
+      - store: store_liquidity
+        mode: deltas
+    output:
+      type: proto:tycho.evm.v1.BlockChanges
+
+params:
+  map_pools_created: "1F98431c8aD98523631AE4a59f267346ea31F984"

--- a/substreams/ethereum-uniswap-v3-logs-only/arbitrum-uniswap-v3.yaml
+++ b/substreams/ethereum-uniswap-v3-logs-only/arbitrum-uniswap-v3.yaml
@@ -24,7 +24,7 @@ binaries:
 modules:
   - name: map_pools_created
     kind: map
-    initialBlock: 37418321
+    initialBlock: 165
     inputs:
       - params: string
       - source: sf.ethereum.type.v2.Block
@@ -33,7 +33,7 @@ modules:
 
   - name: store_pools
     kind: store
-    initialBlock: 37418321
+    initialBlock: 165
     updatePolicy: set_if_not_exists
     valueType: proto:uniswap.v3.Pool
     inputs:
@@ -41,7 +41,7 @@ modules:
 
   - name: map_events
     kind: map
-    initialBlock: 37418321
+    initialBlock: 165
     inputs:
       - source: sf.ethereum.type.v2.Block
       - store: store_pools
@@ -50,7 +50,7 @@ modules:
 
   - name: map_balance_changes
     kind: map
-    initialBlock: 37418321
+    initialBlock: 165
     inputs:
       - map: map_events
     output:
@@ -58,7 +58,7 @@ modules:
 
   - name: store_pools_balances
     kind: store
-    initialBlock: 37418321
+    initialBlock: 165
     updatePolicy: add
     valueType: bigint
     inputs:
@@ -66,7 +66,7 @@ modules:
 
   - name: map_ticks_changes
     kind: map
-    initialBlock: 37418321
+    initialBlock: 165
     inputs:
       - map: map_events
     output:
@@ -74,7 +74,7 @@ modules:
 
   - name: store_ticks_liquidity
     kind: store
-    initialBlock: 37418321
+    initialBlock: 165
     updatePolicy: add
     valueType: bigint
     inputs:
@@ -82,7 +82,7 @@ modules:
 
   - name: store_pool_current_tick
     kind: store
-    initialBlock: 37418321
+    initialBlock: 165
     updatePolicy: set
     valueType: int64
     inputs:
@@ -90,7 +90,7 @@ modules:
 
   - name: map_liquidity_changes
     kind: map
-    initialBlock: 37418321
+    initialBlock: 165
     inputs:
       - map: map_events
       - store: store_pool_current_tick
@@ -99,7 +99,7 @@ modules:
 
   - name: store_liquidity
     kind: store
-    initialBlock: 37418321
+    initialBlock: 165
     updatePolicy: set_sum
     valueType: bigint
     inputs:
@@ -107,7 +107,7 @@ modules:
 
   - name: map_protocol_changes
     kind: map
-    initialBlock: 37418321
+    initialBlock: 165
     inputs:
       - source: sf.ethereum.type.v2.Block
       - map: map_pools_created

--- a/substreams/ethereum-uniswap-v4/no-hooks/arbitrum-uniswap-v4-no-hooks.yaml
+++ b/substreams/ethereum-uniswap-v4/no-hooks/arbitrum-uniswap-v4-no-hooks.yaml
@@ -1,0 +1,138 @@
+specVersion: v0.1.0
+package:
+  name: "arbitrum_uniswap_v4_no_hooks"
+  version: v0.4.1
+  url: "https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/substreams/ethereum-uniswap-v4/no-hooks"
+
+protobuf:
+  files:
+    - tycho/evm/v1/common.proto
+    - tycho/evm/v1/utils.proto
+    - uniswap.proto
+  importPaths:
+    - ../../../proto
+    - ../shared/proto
+  excludePaths:
+    - sf/substreams
+    - google
+    - tycho
+
+binaries:
+  default:
+    type: wasm/rust-v1
+    file: ../target/wasm32-unknown-unknown/release/ethereum_uniswap_v4_no_hooks.wasm
+
+modules:
+  - name: map_pools_created
+    kind: map
+    initialBlock: 297842872
+    inputs:
+      - params: string
+      - source: sf.ethereum.type.v2.Block
+    output:
+      type: proto:tycho.evm.v1.BlockChanges
+
+  - name: store_pools
+    kind: store
+    initialBlock: 297842872
+    updatePolicy: set_if_not_exists
+    valueType: proto:uniswap.v4.Pool
+    inputs:
+      - map: map_pools_created
+
+  - name: map_events
+    kind: map
+    initialBlock: 297842872
+    inputs:
+      - source: sf.ethereum.type.v2.Block
+      - store: store_pools
+    output:
+      type: proto:uniswap.v4.Events
+
+  - name: store_pool_current_tick
+    kind: store
+    initialBlock: 297842872
+    updatePolicy: set
+    valueType: int64
+    inputs:
+      - map: map_events
+
+  - name: store_pool_current_sqrt_price
+    kind: store
+    initialBlock: 297842872
+    updatePolicy: set
+    valueType: bigint
+    inputs:
+      - map: map_events
+
+  - name: map_balance_changes
+    kind: map
+    initialBlock: 297842872
+    inputs:
+      - map: map_events
+      - store: store_pool_current_sqrt_price
+    output:
+      type: proto:tycho.evm.v1.BlockBalanceDeltas
+
+  - name: store_pools_balances
+    kind: store
+    initialBlock: 297842872
+    updatePolicy: add
+    valueType: bigint
+    inputs:
+      - map: map_balance_changes
+
+  - name: map_ticks_changes
+    kind: map
+    initialBlock: 297842872
+    inputs:
+      - map: map_events
+    output:
+      type: proto:uniswap.v4.TickDeltas
+
+  - name: store_ticks_liquidity
+    kind: store
+    initialBlock: 297842872
+    updatePolicy: add
+    valueType: bigint
+    inputs:
+      - map: map_ticks_changes
+
+  - name: map_liquidity_changes
+    kind: map
+    initialBlock: 297842872
+    inputs:
+      - map: map_events
+      - store: store_pool_current_tick
+    output:
+      type: proto:uniswap.v4.LiquidityChanges
+
+  - name: store_liquidity
+    kind: store
+    initialBlock: 297842872
+    updatePolicy: set_sum
+    valueType: bigint
+    inputs:
+      - map: map_liquidity_changes
+
+  - name: map_protocol_changes
+    kind: map
+    initialBlock: 297842872
+    inputs:
+      - source: sf.ethereum.type.v2.Block
+      - map: map_pools_created
+      - map: map_events
+      - map: map_balance_changes
+      - store: store_pools_balances
+        mode: deltas
+      - map: map_ticks_changes
+      - store: store_ticks_liquidity
+        mode: deltas
+      - map: map_liquidity_changes
+      - store: store_liquidity
+        mode: deltas
+    output:
+      type: proto:tycho.evm.v1.BlockChanges
+
+params:
+  map_pools_created: "360E68faCcca8cA495c1B759Fd9EEe466db9FB32"

--- a/substreams/publish.sh
+++ b/substreams/publish.sh
@@ -17,8 +17,38 @@ fi
 package=$1
 yaml_name=$2
 
-# Fetch version from Cargo.toml
-cargo_version=$(cargo pkgid -p "$package" | cut -d# -f2 | cut -d: -f2)
+# Resolve package metadata from Cargo.toml (supports nested package paths)
+cargo_toml="./$package/Cargo.toml"
+if [[ ! -f "$cargo_toml" ]]; then
+    echo "Error: Cargo.toml not found at $cargo_toml"
+    exit 1
+fi
+
+cargo_package_name=$(awk '
+    /^\[package\]/ { in_package=1; next }
+    /^\[/ && in_package { in_package=0 }
+    in_package && $1 == "name" {
+        gsub(/"/, "", $3)
+        print $3
+        exit
+    }
+' "$cargo_toml")
+
+cargo_version=$(awk '
+    /^\[package\]/ { in_package=1; next }
+    /^\[/ && in_package { in_package=0 }
+    in_package && $1 == "version" {
+        gsub(/"/, "", $3)
+        print $3
+        exit
+    }
+' "$cargo_toml")
+
+if [[ -z "$cargo_package_name" || -z "$cargo_version" ]]; then
+    echo "Error: Unable to parse package name/version from $cargo_toml"
+    exit 1
+fi
+
 version="v${cargo_version}"
 
 # Construct the YAML file path
@@ -55,8 +85,8 @@ fi
 
 set -e  # Exit the script if any command fails
 
-# Build the package
-cargo build --target wasm32-unknown-unknown --release -p "$package"
+# Build the package (using resolved Cargo package name)
+cargo build --target wasm32-unknown-unknown --release -p "$cargo_package_name"
 
 # Create output directory
 mkdir -p ./target/spkg/


### PR DESCRIPTION
## Summary
- Add `arbitrum-uniswap-v4-no-hooks.yaml` — PoolManager `0x360E68faCcca8cA495c1B759Fd9EEe466db9FB32`, block `297842872`
- Add `arbitrum-pancakeswap-v3.yaml` — Factory `0x0BFbCF9fa4f9C56B0F40a671Ad40E0805A091865`, block `119957974`
- Both share existing wasm binaries; only package name, initialBlock, and contract params differ

Part of ENG-5632 (Arbitrum Protocol Deployment). UniswapV2 and V3 Arbitrum YAMLs already exist.

## Test plan
- [x] Verify YAML syntax is valid
- [x] Compare structure against existing Base equivalents
- [ ] Build `.spkg` packages from these manifests
- [ ] Upload to S3 and verify indexer can load them

🤖 Generated with [Claude Code](https://claude.com/claude-code)