### PR TITLE
feat: Add Polygon substreams YAML configs

### DIFF
--- a/substreams/Cargo.lock
+++ b/substreams/Cargo.lock
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "ethereum-uniswap-v2"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "ethabi 18.0.0",

--- a/substreams/ethereum-uniswap-v2/Cargo.toml
+++ b/substreams/ethereum-uniswap-v2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum-uniswap-v2"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 
 [lib]

--- a/substreams/ethereum-uniswap-v2/polygon-quickswap-v2.yaml
+++ b/substreams/ethereum-uniswap-v2/polygon-quickswap-v2.yaml
@@ -1,0 +1,47 @@
+specVersion: v0.1.0
+package:
+  name: "polygon_quickswap_v2"
+  version: v0.3.2
+  url: "https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/substreams/ethereum-uniswap-v2"
+
+protobuf:
+  files:
+    - uniswap.proto
+  importPaths:
+    - ./proto/v1
+
+binaries:
+  default:
+    type: wasm/rust-v1
+    file: ../target/wasm32-unknown-unknown/release/ethereum_uniswap_v2.wasm
+
+modules:
+  - name: map_pools_created
+    kind: map
+    initialBlock: 4931780
+    inputs:
+      - params: string
+      - source: sf.ethereum.type.v2.Block
+    output:
+      type: proto:tycho.evm.v1.BlockChanges
+
+  - name: store_pools
+    kind: store
+    initialBlock: 4931780
+    updatePolicy: set_if_not_exists
+    valueType: proto:tycho.evm.uniswap.v2.Pool
+    inputs:
+      - map: map_pools_created
+
+  - name: map_pool_events
+    kind: map
+    initialBlock: 4931780
+    inputs:
+      - source: sf.ethereum.type.v2.Block
+      - map: map_pools_created
+      - store: store_pools
+    output:
+      type: proto:tycho.evm.v1.BlockChanges
+
+params:
+  map_pools_created: factory_address=5757371414417b8C6CAad45bAeF941aBc7d3Ab32&protocol_type_name=quickswap_v2_pool

--- a/substreams/ethereum-uniswap-v2/polygon-quickswap-v2.yaml
+++ b/substreams/ethereum-uniswap-v2/polygon-quickswap-v2.yaml
@@ -6,9 +6,11 @@ package:
 
 protobuf:
   files:
+    - tycho/evm/v1/common.proto
     - uniswap.proto
   importPaths:
     - ./proto/v1
+    - ../../proto/
 
 binaries:
   default:

--- a/substreams/ethereum-uniswap-v2/polygon-uniswap-v2.yaml
+++ b/substreams/ethereum-uniswap-v2/polygon-uniswap-v2.yaml
@@ -18,7 +18,7 @@ binaries:
 modules:
   - name: map_pools_created
     kind: map
-    initialBlock: 57036835
+    initialBlock: 49948178
     inputs:
       - params: string
       - source: sf.ethereum.type.v2.Block
@@ -27,7 +27,7 @@ modules:
 
   - name: store_pools
     kind: store
-    initialBlock: 57036835
+    initialBlock: 49948178
     updatePolicy: set_if_not_exists
     valueType: proto:tycho.evm.uniswap.v2.Pool
     inputs:
@@ -35,7 +35,7 @@ modules:
 
   - name: map_pool_events
     kind: map
-    initialBlock: 57036835
+    initialBlock: 49948178
     inputs:
       - source: sf.ethereum.type.v2.Block
       - map: map_pools_created

--- a/substreams/ethereum-uniswap-v2/polygon-uniswap-v2.yaml
+++ b/substreams/ethereum-uniswap-v2/polygon-uniswap-v2.yaml
@@ -6,9 +6,11 @@ package:
 
 protobuf:
   files:
+    - tycho/evm/v1/common.proto
     - uniswap.proto
   importPaths:
     - ./proto/v1
+    - ../../proto/
 
 binaries:
   default:

--- a/substreams/ethereum-uniswap-v2/polygon-uniswap-v2.yaml
+++ b/substreams/ethereum-uniswap-v2/polygon-uniswap-v2.yaml
@@ -1,0 +1,47 @@
+specVersion: v0.1.0
+package:
+  name: "polygon_uniswap_v2"
+  version: v0.3.2
+  url: "https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/substreams/ethereum-uniswap-v2"
+
+protobuf:
+  files:
+    - uniswap.proto
+  importPaths:
+    - ./proto/v1
+
+binaries:
+  default:
+    type: wasm/rust-v1
+    file: ../target/wasm32-unknown-unknown/release/ethereum_uniswap_v2.wasm
+
+modules:
+  - name: map_pools_created
+    kind: map
+    initialBlock: 57036835
+    inputs:
+      - params: string
+      - source: sf.ethereum.type.v2.Block
+    output:
+      type: proto:tycho.evm.v1.BlockChanges
+
+  - name: store_pools
+    kind: store
+    initialBlock: 57036835
+    updatePolicy: set_if_not_exists
+    valueType: proto:tycho.evm.uniswap.v2.Pool
+    inputs:
+      - map: map_pools_created
+
+  - name: map_pool_events
+    kind: map
+    initialBlock: 57036835
+    inputs:
+      - source: sf.ethereum.type.v2.Block
+      - map: map_pools_created
+      - store: store_pools
+    output:
+      type: proto:tycho.evm.v1.BlockChanges
+
+params:
+  map_pools_created: factory_address=9e5A52f57b3038F1B8EeE45F28b3C1967e22799C&protocol_type_name=uniswap_v2_pool

--- a/substreams/ethereum-uniswap-v3-logs-only/polygon-uniswap-v3.yaml
+++ b/substreams/ethereum-uniswap-v3-logs-only/polygon-uniswap-v3.yaml
@@ -1,0 +1,128 @@
+specVersion: v0.1.0
+package:
+  name: "polygon_uniswap_v3_logs_only"
+  version: v0.1.2
+  url: "https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/substreams/ethereum-uniswap-v3-logs-only"
+
+protobuf:
+  files:
+    - tycho/evm/v1/common.proto
+    - tycho/evm/v1/utils.proto
+    - uniswap.proto
+  importPaths:
+    - ./proto/v1
+    - ../../proto/
+  excludePaths:
+    - sf/ethereum
+    - google
+
+binaries:
+  default:
+    type: wasm/rust-v1
+    file: ../target/wasm32-unknown-unknown/release/ethereum_uniswap_v3_logs_only.wasm
+
+modules:
+  - name: map_pools_created
+    kind: map
+    initialBlock: 22757547
+    inputs:
+      - params: string
+      - source: sf.ethereum.type.v2.Block
+    output:
+      type: proto:tycho.evm.v1.BlockChanges
+
+  - name: store_pools
+    kind: store
+    initialBlock: 22757547
+    updatePolicy: set_if_not_exists
+    valueType: proto:uniswap.v3.Pool
+    inputs:
+      - map: map_pools_created
+
+  - name: map_events
+    kind: map
+    initialBlock: 22757547
+    inputs:
+      - source: sf.ethereum.type.v2.Block
+      - store: store_pools
+    output:
+      type: proto:uniswap.v3.Events
+
+  - name: map_balance_changes
+    kind: map
+    initialBlock: 22757547
+    inputs:
+      - map: map_events
+    output:
+      type: proto:tycho.evm.v1.BlockBalanceDeltas
+
+  - name: store_pools_balances
+    kind: store
+    initialBlock: 22757547
+    updatePolicy: add
+    valueType: bigint
+    inputs:
+      - map: map_balance_changes
+
+  - name: map_ticks_changes
+    kind: map
+    initialBlock: 22757547
+    inputs:
+      - map: map_events
+    output:
+      type: proto:uniswap.v3.TickDeltas
+
+  - name: store_ticks_liquidity
+    kind: store
+    initialBlock: 22757547
+    updatePolicy: add
+    valueType: bigint
+    inputs:
+      - map: map_ticks_changes
+
+  - name: store_pool_current_tick
+    kind: store
+    initialBlock: 22757547
+    updatePolicy: set
+    valueType: int64
+    inputs:
+      - map: map_events
+
+  - name: map_liquidity_changes
+    kind: map
+    initialBlock: 22757547
+    inputs:
+      - map: map_events
+      - store: store_pool_current_tick
+    output:
+      type: proto:uniswap.v3.LiquidityChanges
+
+  - name: store_liquidity
+    kind: store
+    initialBlock: 22757547
+    updatePolicy: set_sum
+    valueType: bigint
+    inputs:
+      - map: map_liquidity_changes
+
+  - name: map_protocol_changes
+    kind: map
+    initialBlock: 22757547
+    inputs:
+      - source: sf.ethereum.type.v2.Block
+      - map: map_pools_created
+      - map: map_events
+      - map: map_balance_changes
+      - store: store_pools_balances
+        mode: deltas
+      - map: map_ticks_changes
+      - store: store_ticks_liquidity
+        mode: deltas
+      - map: map_liquidity_changes
+      - store: store_liquidity
+        mode: deltas
+    output:
+      type: proto:tycho.evm.v1.BlockChanges
+
+params:
+  map_pools_created: "1F98431c8aD98523631AE4a59f267346ea31F984"

--- a/substreams/ethereum-uniswap-v4/no-hooks/arbitrum-uniswap-v4-no-hooks.yaml
+++ b/substreams/ethereum-uniswap-v4/no-hooks/arbitrum-uniswap-v4-no-hooks.yaml
@@ -20,7 +20,7 @@ protobuf:
 binaries:
   default:
     type: wasm/rust-v1
-    file: ../target/wasm32-unknown-unknown/release/ethereum_uniswap_v4_no_hooks.wasm
+    file: ../../target/wasm32-unknown-unknown/release/ethereum_uniswap_v4_no_hooks.wasm
 
 modules:
   - name: map_pools_created

--- a/substreams/ethereum-uniswap-v4/no-hooks/base-uniswap-v4-no-hooks.yaml
+++ b/substreams/ethereum-uniswap-v4/no-hooks/base-uniswap-v4-no-hooks.yaml
@@ -20,7 +20,7 @@ protobuf:
 binaries:
   default:
     type: wasm/rust-v1
-    file: ../target/wasm32-unknown-unknown/release/ethereum_uniswap_v4_no_hooks.wasm
+    file: ../../target/wasm32-unknown-unknown/release/ethereum_uniswap_v4_no_hooks.wasm
 
 modules:
   - name: map_pools_created

--- a/substreams/ethereum-uniswap-v4/no-hooks/bsc-uniswap-v4-no-hooks.yaml
+++ b/substreams/ethereum-uniswap-v4/no-hooks/bsc-uniswap-v4-no-hooks.yaml
@@ -20,7 +20,7 @@ protobuf:
 binaries:
   default:
     type: wasm/rust-v1
-    file: ../target/wasm32-unknown-unknown/release/ethereum_uniswap_v4_no_hooks.wasm
+    file: ../../target/wasm32-unknown-unknown/release/ethereum_uniswap_v4_no_hooks.wasm
 
 modules:
   - name: map_pools_created

--- a/substreams/ethereum-uniswap-v4/no-hooks/ethereum-uniswap-v4-no-hooks.yaml
+++ b/substreams/ethereum-uniswap-v4/no-hooks/ethereum-uniswap-v4-no-hooks.yaml
@@ -20,7 +20,7 @@ protobuf:
 binaries:
   default:
     type: wasm/rust-v1
-    file: ../target/wasm32-unknown-unknown/release/ethereum_uniswap_v4_no_hooks.wasm
+    file: ../../target/wasm32-unknown-unknown/release/ethereum_uniswap_v4_no_hooks.wasm
 
 modules:
   - name: map_pools_created

--- a/substreams/ethereum-uniswap-v4/no-hooks/polygon-uniswap-v4-no-hooks.yaml
+++ b/substreams/ethereum-uniswap-v4/no-hooks/polygon-uniswap-v4-no-hooks.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: "polygon_uniswap_v4_no_hooks"
-  version: v0.4.1
+  version: v0.4.2
   url: "https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/substreams/ethereum-uniswap-v4/no-hooks"
 
 protobuf:
@@ -20,7 +20,7 @@ protobuf:
 binaries:
   default:
     type: wasm/rust-v1
-    file: ../target/wasm32-unknown-unknown/release/ethereum_uniswap_v4_no_hooks.wasm
+    file: ../../target/wasm32-unknown-unknown/release/ethereum_uniswap_v4_no_hooks.wasm
 
 modules:
   - name: map_pools_created

--- a/substreams/ethereum-uniswap-v4/no-hooks/polygon-uniswap-v4-no-hooks.yaml
+++ b/substreams/ethereum-uniswap-v4/no-hooks/polygon-uniswap-v4-no-hooks.yaml
@@ -25,7 +25,7 @@ binaries:
 modules:
   - name: map_pools_created
     kind: map
-    initialBlock: 67820000
+    initialBlock: 66980384
     inputs:
       - params: string
       - source: sf.ethereum.type.v2.Block
@@ -34,7 +34,7 @@ modules:
 
   - name: store_pools
     kind: store
-    initialBlock: 67820000
+    initialBlock: 66980384
     updatePolicy: set_if_not_exists
     valueType: proto:uniswap.v4.Pool
     inputs:
@@ -42,7 +42,7 @@ modules:
 
   - name: map_events
     kind: map
-    initialBlock: 67820000
+    initialBlock: 66980384
     inputs:
       - source: sf.ethereum.type.v2.Block
       - store: store_pools
@@ -51,7 +51,7 @@ modules:
 
   - name: store_pool_current_tick
     kind: store
-    initialBlock: 67820000
+    initialBlock: 66980384
     updatePolicy: set
     valueType: int64
     inputs:
@@ -59,7 +59,7 @@ modules:
 
   - name: store_pool_current_sqrt_price
     kind: store
-    initialBlock: 67820000
+    initialBlock: 66980384
     updatePolicy: set
     valueType: bigint
     inputs:
@@ -67,7 +67,7 @@ modules:
 
   - name: map_balance_changes
     kind: map
-    initialBlock: 67820000
+    initialBlock: 66980384
     inputs:
       - map: map_events
       - store: store_pool_current_sqrt_price
@@ -76,7 +76,7 @@ modules:
 
   - name: store_pools_balances
     kind: store
-    initialBlock: 67820000
+    initialBlock: 66980384
     updatePolicy: add
     valueType: bigint
     inputs:
@@ -84,7 +84,7 @@ modules:
 
   - name: map_ticks_changes
     kind: map
-    initialBlock: 67820000
+    initialBlock: 66980384
     inputs:
       - map: map_events
     output:
@@ -92,7 +92,7 @@ modules:
 
   - name: store_ticks_liquidity
     kind: store
-    initialBlock: 67820000
+    initialBlock: 66980384
     updatePolicy: add
     valueType: bigint
     inputs:
@@ -100,7 +100,7 @@ modules:
 
   - name: map_liquidity_changes
     kind: map
-    initialBlock: 67820000
+    initialBlock: 66980384
     inputs:
       - map: map_events
       - store: store_pool_current_tick
@@ -109,7 +109,7 @@ modules:
 
   - name: store_liquidity
     kind: store
-    initialBlock: 67820000
+    initialBlock: 66980384
     updatePolicy: set_sum
     valueType: bigint
     inputs:
@@ -117,7 +117,7 @@ modules:
 
   - name: map_protocol_changes
     kind: map
-    initialBlock: 67820000
+    initialBlock: 66980384
     inputs:
       - source: sf.ethereum.type.v2.Block
       - map: map_pools_created

--- a/substreams/ethereum-uniswap-v4/no-hooks/polygon-uniswap-v4-no-hooks.yaml
+++ b/substreams/ethereum-uniswap-v4/no-hooks/polygon-uniswap-v4-no-hooks.yaml
@@ -1,0 +1,138 @@
+specVersion: v0.1.0
+package:
+  name: "polygon_uniswap_v4_no_hooks"
+  version: v0.4.1
+  url: "https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/substreams/ethereum-uniswap-v4/no-hooks"
+
+protobuf:
+  files:
+    - tycho/evm/v1/common.proto
+    - tycho/evm/v1/utils.proto
+    - uniswap.proto
+  importPaths:
+    - ../../../proto
+    - ../shared/proto
+  excludePaths:
+    - sf/substreams
+    - google
+    - tycho
+
+binaries:
+  default:
+    type: wasm/rust-v1
+    file: ../target/wasm32-unknown-unknown/release/ethereum_uniswap_v4_no_hooks.wasm
+
+modules:
+  - name: map_pools_created
+    kind: map
+    initialBlock: 67820000
+    inputs:
+      - params: string
+      - source: sf.ethereum.type.v2.Block
+    output:
+      type: proto:tycho.evm.v1.BlockChanges
+
+  - name: store_pools
+    kind: store
+    initialBlock: 67820000
+    updatePolicy: set_if_not_exists
+    valueType: proto:uniswap.v4.Pool
+    inputs:
+      - map: map_pools_created
+
+  - name: map_events
+    kind: map
+    initialBlock: 67820000
+    inputs:
+      - source: sf.ethereum.type.v2.Block
+      - store: store_pools
+    output:
+      type: proto:uniswap.v4.Events
+
+  - name: store_pool_current_tick
+    kind: store
+    initialBlock: 67820000
+    updatePolicy: set
+    valueType: int64
+    inputs:
+      - map: map_events
+
+  - name: store_pool_current_sqrt_price
+    kind: store
+    initialBlock: 67820000
+    updatePolicy: set
+    valueType: bigint
+    inputs:
+      - map: map_events
+
+  - name: map_balance_changes
+    kind: map
+    initialBlock: 67820000
+    inputs:
+      - map: map_events
+      - store: store_pool_current_sqrt_price
+    output:
+      type: proto:tycho.evm.v1.BlockBalanceDeltas
+
+  - name: store_pools_balances
+    kind: store
+    initialBlock: 67820000
+    updatePolicy: add
+    valueType: bigint
+    inputs:
+      - map: map_balance_changes
+
+  - name: map_ticks_changes
+    kind: map
+    initialBlock: 67820000
+    inputs:
+      - map: map_events
+    output:
+      type: proto:uniswap.v4.TickDeltas
+
+  - name: store_ticks_liquidity
+    kind: store
+    initialBlock: 67820000
+    updatePolicy: add
+    valueType: bigint
+    inputs:
+      - map: map_ticks_changes
+
+  - name: map_liquidity_changes
+    kind: map
+    initialBlock: 67820000
+    inputs:
+      - map: map_events
+      - store: store_pool_current_tick
+    output:
+      type: proto:uniswap.v4.LiquidityChanges
+
+  - name: store_liquidity
+    kind: store
+    initialBlock: 67820000
+    updatePolicy: set_sum
+    valueType: bigint
+    inputs:
+      - map: map_liquidity_changes
+
+  - name: map_protocol_changes
+    kind: map
+    initialBlock: 67820000
+    inputs:
+      - source: sf.ethereum.type.v2.Block
+      - map: map_pools_created
+      - map: map_events
+      - map: map_balance_changes
+      - store: store_pools_balances
+        mode: deltas
+      - map: map_ticks_changes
+      - store: store_ticks_liquidity
+        mode: deltas
+      - map: map_liquidity_changes
+      - store: store_liquidity
+        mode: deltas
+    output:
+      type: proto:tycho.evm.v1.BlockChanges
+
+params:
+  map_pools_created: "67366782805870060151383F4BbFF9daB53e5cD6"

--- a/substreams/ethereum-uniswap-v4/no-hooks/unichain-uniswap-v4-no-hooks.yaml
+++ b/substreams/ethereum-uniswap-v4/no-hooks/unichain-uniswap-v4-no-hooks.yaml
@@ -20,7 +20,7 @@ protobuf:
 binaries:
   default:
     type: wasm/rust-v1
-    file: ..//target/wasm32-unknown-unknown/release/ethereum_uniswap_v4_no_hooks.wasm
+    file: ../../target/wasm32-unknown-unknown/release/ethereum_uniswap_v4_no_hooks.wasm
 
 modules:
   - name: map_pools_created

--- a/substreams/publish.sh
+++ b/substreams/publish.sh
@@ -2,15 +2,16 @@
 
 # Manual publish script for substream packages.
 # Builds, packs, and publishes a substream package to the public S3 repository.
-# Usage: ./publish.sh <package-name> <yaml-name>
-#   package-name: The name of the package to build
+# Usage: ./publish.sh <package-dir> <yaml-name>
+#   package-dir: Path to the package directory relative to this script
+#                For nested packages use the subdirectory path (e.g. ethereum-uniswap-v4/no-hooks)
 #   yaml-name: The name of the YAML file (without .yaml extension)
-# The version will be automatically fetched from the package's Cargo.toml
+# The package name and version will be automatically fetched from the package's Cargo.toml
 
 # Check if required arguments are provided
 if [ -z "$1" ] || [ -z "$2" ]; then
-    echo "Error: package name and yaml name are required!"
-    echo "Usage: $0 <package-name> <yaml-name>"
+    echo "Error: package directory and yaml name are required!"
+    echo "Usage: $0 <package-dir> <yaml-name>"
     exit 1
 fi
 
@@ -62,7 +63,7 @@ fi
 
 # Determine the version prefix based on the YAML file name
 if [ "$yaml_name" = "substreams" ]; then
-    version_prefix="$package"
+    version_prefix="$cargo_package_name"
 else
     version_prefix="${yaml_name}"
 fi
@@ -70,7 +71,7 @@ fi
 set -e  # Exit the script if any command fails
 
 echo ""
-echo "Substreams package: $package"
+echo "Substreams package: $cargo_package_name"
 echo "YAML config: $yaml_file"
 echo "Version: $version"
 echo ""
@@ -93,7 +94,7 @@ mkdir -p ./target/spkg/
 
 # Pack and upload the substreams package
 REPOSITORY=${REPOSITORY:-"s3://repo.propellerheads-propellerheads/substreams"}
-repository_path="$REPOSITORY/$package/$version_prefix-$version.spkg"
+repository_path="$REPOSITORY/$version_prefix/$version_prefix-$version.spkg"
 output_file="./target/spkg/$version_prefix-$version.spkg"
 
 substreams pack "$yaml_file" -o "$output_file"
@@ -115,4 +116,3 @@ aws s3 cp "$output_file" "$repository_path"
 echo "------------------------------------------------------"
 echo "PUBLISHED SUBSTREAMS PACKAGE: '$repository_path'"
 echo "------------------------------------------------------"
-


### PR DESCRIPTION
## Summary
- Add QuickSwap V2 substream config (`polygon-quickswap-v2.yaml`, factory `5757371414417b8C6CAad45bAeF941aBc7d3Ab32`, initial block 4931780)
- Add Uniswap V2 substream config (`polygon-uniswap-v2.yaml`, factory `9e5A52f57b3038F1B8EeE45F28b3C1967e22799C`, initial block 57036835)
- Add Uniswap V3 logs-only substream config (`polygon-uniswap-v3.yaml`, factory `1F98431c8aD98523631AE4a59f267346ea31F984`, initial block 22757547)
- Add Uniswap V4 no-hooks substream config (`polygon-uniswap-v4-no-hooks.yaml`, pool manager `67366782805870060151383F4BbFF9daB53e5cD6`, initial block 67820000)

ENG-5655, ENG-5656, ENG-5657, ENG-5658

## Test plan
- [ ] Build each spkg: `substreams pack substreams/ethereum-uniswap-v2/polygon-quickswap-v2.yaml`
- [ ] Build each spkg: `substreams pack substreams/ethereum-uniswap-v2/polygon-uniswap-v2.yaml`
- [ ] Build each spkg: `substreams pack substreams/ethereum-uniswap-v3-logs-only/polygon-uniswap-v3.yaml`
- [ ] Build each spkg: `substreams pack substreams/ethereum-uniswap-v4/no-hooks/polygon-uniswap-v4-no-hooks.yaml`
- [ ] Verify YAML structure matches existing chain configs (Arbitrum, Base, BSC)
- [ ] Verify factory addresses and initial blocks are correct for Polygon

🤖 Generated with [Claude Code](https://claude.com/claude-code)