### PR TITLE
Add Balancer V3 multi-network 

### DIFF
--- a/protocol-testing/src/test_runner.rs
+++ b/protocol-testing/src/test_runner.rs
@@ -69,6 +69,7 @@ static CLONE_TO_BASE_PROTOCOL: LazyLock<HashMap<&str, &str>> = LazyLock::new(|| 
     HashMap::from([
         ("ethereum-sushiswap-v2", "ethereum-uniswap-v2"),
         ("ethereum-pancakeswap-v2", "ethereum-uniswap-v2"),
+        ("base-balancer-v3", "ethereum-balancer-v3"),
     ])
 });
 

--- a/substreams/ethereum-balancer-v3/arbitrum-balancer-v3.yaml
+++ b/substreams/ethereum-balancer-v3/arbitrum-balancer-v3.yaml
@@ -1,6 +1,6 @@
 specVersion: v0.1.0
 package:
-  name: "ethereum_balancer_v3"
+  name: "arbitrum_balancer_v3"
   version: v0.4.0
 
 protobuf:
@@ -18,7 +18,7 @@ binaries:
 modules:
   - name: map_components
     kind: map
-    initialBlock: 21332121
+    initialBlock: 297810187
     inputs:
       - params: string
       - source: sf.ethereum.type.v2.Block
@@ -27,7 +27,7 @@ modules:
 
   - name: store_components
     kind: store
-    initialBlock: 21332121
+    initialBlock: 297810187
     updatePolicy: set_if_not_exists
     valueType: proto:tycho.evm.v1.ProtocolComponents
     inputs:
@@ -35,7 +35,7 @@ modules:
 
   - name: store_token_set
     kind: store
-    initialBlock: 21332121
+    initialBlock: 297810187
     updatePolicy: set_if_not_exists
     valueType: int64
     inputs:
@@ -43,7 +43,7 @@ modules:
 
   - name: map_relative_balances
     kind: map
-    initialBlock: 21332121
+    initialBlock: 297810187
     inputs:
       - params: string
       - source: sf.ethereum.type.v2.Block
@@ -53,7 +53,7 @@ modules:
 
   - name: store_balances
     kind: store
-    initialBlock: 21332121
+    initialBlock: 297810187
     updatePolicy: add
     valueType: bigint
     inputs:
@@ -61,7 +61,7 @@ modules:
 
   - name: map_protocol_changes
     kind: map
-    initialBlock: 21332121
+    initialBlock: 297810187
     inputs:
       - params: string
       - source: sf.ethereum.type.v2.Block
@@ -70,13 +70,13 @@ modules:
       - store: store_components
       - store: store_token_set
       - store: store_balances
-        mode: deltas # This is the key property that simplifies `BalanceChange` handling
+        mode: deltas
     output:
       type: proto:tycho.evm.v1.BlockChanges
 
 network: mainnet
 
 params:
-  map_components: vault=ba1333333333a1ba1108e8412f11850a5c319ba9&vault_extension=0e8b07657d719b86e06bf0806d6729e3d528c9a9&batch_router=136f1efcc3f8f88516b9e94110d56fdbfb1778d1&permit2=000000000022d473030f116ddee9f6b43ac78ba3&weighted_factory=201efd508c8dfe9de1a13c2452863a78cb2a86cc&stable_factory=b9d01ca61b9c181da1051bfdd28e1097e920ab14
-  map_relative_balances: vault=ba1333333333a1ba1108e8412f11850a5c319ba9&vault_extension=0e8b07657d719b86e06bf0806d6729e3d528c9a9&batch_router=136f1efcc3f8f88516b9e94110d56fdbfb1778d1&permit2=000000000022d473030f116ddee9f6b43ac78ba3&weighted_factory=201efd508c8dfe9de1a13c2452863a78cb2a86cc&stable_factory=b9d01ca61b9c181da1051bfdd28e1097e920ab14
-  map_protocol_changes: vault=ba1333333333a1ba1108e8412f11850a5c319ba9&vault_extension=0e8b07657d719b86e06bf0806d6729e3d528c9a9&batch_router=136f1efcc3f8f88516b9e94110d56fdbfb1778d1&permit2=000000000022d473030f116ddee9f6b43ac78ba3&weighted_factory=201efd508c8dfe9de1a13c2452863a78cb2a86cc&stable_factory=b9d01ca61b9c181da1051bfdd28e1097e920ab14
+  map_components: vault=ba1333333333a1ba1108e8412f11850a5c319ba9&vault_extension=0e8b07657d719b86e06bf0806d6729e3d528c9a9&batch_router=ad89051bed8d96f045e8912ae1672c6c0bf8a85e&permit2=000000000022d473030f116ddee9f6b43ac78ba3&weighted_factory=83bf399fa3dc49af8fb5c34031a50c7c93f56129&stable_factory=1fc7f1f84cfe61a04224ac8d3f87f56214fec08c
+  map_relative_balances: vault=ba1333333333a1ba1108e8412f11850a5c319ba9&vault_extension=0e8b07657d719b86e06bf0806d6729e3d528c9a9&batch_router=ad89051bed8d96f045e8912ae1672c6c0bf8a85e&permit2=000000000022d473030f116ddee9f6b43ac78ba3&weighted_factory=83bf399fa3dc49af8fb5c34031a50c7c93f56129&stable_factory=1fc7f1f84cfe61a04224ac8d3f87f56214fec08c
+  map_protocol_changes: vault=ba1333333333a1ba1108e8412f11850a5c319ba9&vault_extension=0e8b07657d719b86e06bf0806d6729e3d528c9a9&batch_router=ad89051bed8d96f045e8912ae1672c6c0bf8a85e&permit2=000000000022d473030f116ddee9f6b43ac78ba3&weighted_factory=83bf399fa3dc49af8fb5c34031a50c7c93f56129&stable_factory=1fc7f1f84cfe61a04224ac8d3f87f56214fec08c

--- a/substreams/ethereum-balancer-v3/base-balancer-v3.yaml
+++ b/substreams/ethereum-balancer-v3/base-balancer-v3.yaml
@@ -1,6 +1,6 @@
 specVersion: v0.1.0
 package:
-  name: "ethereum_balancer_v3"
+  name: "base_balancer_v3"
   version: v0.4.0
 
 protobuf:
@@ -18,7 +18,7 @@ binaries:
 modules:
   - name: map_components
     kind: map
-    initialBlock: 21332121
+    initialBlock: 25343854
     inputs:
       - params: string
       - source: sf.ethereum.type.v2.Block
@@ -27,7 +27,7 @@ modules:
 
   - name: store_components
     kind: store
-    initialBlock: 21332121
+    initialBlock: 25343854
     updatePolicy: set_if_not_exists
     valueType: proto:tycho.evm.v1.ProtocolComponents
     inputs:
@@ -35,7 +35,7 @@ modules:
 
   - name: store_token_set
     kind: store
-    initialBlock: 21332121
+    initialBlock: 25343854
     updatePolicy: set_if_not_exists
     valueType: int64
     inputs:
@@ -43,7 +43,7 @@ modules:
 
   - name: map_relative_balances
     kind: map
-    initialBlock: 21332121
+    initialBlock: 25343854
     inputs:
       - params: string
       - source: sf.ethereum.type.v2.Block
@@ -53,7 +53,7 @@ modules:
 
   - name: store_balances
     kind: store
-    initialBlock: 21332121
+    initialBlock: 25343854
     updatePolicy: add
     valueType: bigint
     inputs:
@@ -61,7 +61,7 @@ modules:
 
   - name: map_protocol_changes
     kind: map
-    initialBlock: 21332121
+    initialBlock: 25343854
     inputs:
       - params: string
       - source: sf.ethereum.type.v2.Block
@@ -70,13 +70,13 @@ modules:
       - store: store_components
       - store: store_token_set
       - store: store_balances
-        mode: deltas # This is the key property that simplifies `BalanceChange` handling
+        mode: deltas
     output:
       type: proto:tycho.evm.v1.BlockChanges
 
 network: mainnet
 
 params:
-  map_components: vault=ba1333333333a1ba1108e8412f11850a5c319ba9&vault_extension=0e8b07657d719b86e06bf0806d6729e3d528c9a9&batch_router=136f1efcc3f8f88516b9e94110d56fdbfb1778d1&permit2=000000000022d473030f116ddee9f6b43ac78ba3&weighted_factory=201efd508c8dfe9de1a13c2452863a78cb2a86cc&stable_factory=b9d01ca61b9c181da1051bfdd28e1097e920ab14
-  map_relative_balances: vault=ba1333333333a1ba1108e8412f11850a5c319ba9&vault_extension=0e8b07657d719b86e06bf0806d6729e3d528c9a9&batch_router=136f1efcc3f8f88516b9e94110d56fdbfb1778d1&permit2=000000000022d473030f116ddee9f6b43ac78ba3&weighted_factory=201efd508c8dfe9de1a13c2452863a78cb2a86cc&stable_factory=b9d01ca61b9c181da1051bfdd28e1097e920ab14
-  map_protocol_changes: vault=ba1333333333a1ba1108e8412f11850a5c319ba9&vault_extension=0e8b07657d719b86e06bf0806d6729e3d528c9a9&batch_router=136f1efcc3f8f88516b9e94110d56fdbfb1778d1&permit2=000000000022d473030f116ddee9f6b43ac78ba3&weighted_factory=201efd508c8dfe9de1a13c2452863a78cb2a86cc&stable_factory=b9d01ca61b9c181da1051bfdd28e1097e920ab14
+  map_components: vault=ba1333333333a1ba1108e8412f11850a5c319ba9&vault_extension=0e8b07657d719b86e06bf0806d6729e3d528c9a9&batch_router=85a80afee867adf27b50bdb7b76da70f1e853062&permit2=000000000022d473030f116ddee9f6b43ac78ba3&weighted_factory=bdbadc891bb95dee80ebc491699228ef0f7d6ff1&stable_factory=fc2986feab34713e659da84f3b1fa32c1da95832
+  map_relative_balances: vault=ba1333333333a1ba1108e8412f11850a5c319ba9&vault_extension=0e8b07657d719b86e06bf0806d6729e3d528c9a9&batch_router=85a80afee867adf27b50bdb7b76da70f1e853062&permit2=000000000022d473030f116ddee9f6b43ac78ba3&weighted_factory=bdbadc891bb95dee80ebc491699228ef0f7d6ff1&stable_factory=fc2986feab34713e659da84f3b1fa32c1da95832
+  map_protocol_changes: vault=ba1333333333a1ba1108e8412f11850a5c319ba9&vault_extension=0e8b07657d719b86e06bf0806d6729e3d528c9a9&batch_router=85a80afee867adf27b50bdb7b76da70f1e853062&permit2=000000000022d473030f116ddee9f6b43ac78ba3&weighted_factory=bdbadc891bb95dee80ebc491699228ef0f7d6ff1&stable_factory=fc2986feab34713e659da84f3b1fa32c1da95832

--- a/substreams/ethereum-balancer-v3/gnosis-balancer-v3.yaml
+++ b/substreams/ethereum-balancer-v3/gnosis-balancer-v3.yaml
@@ -1,6 +1,6 @@
 specVersion: v0.1.0
 package:
-  name: "ethereum_balancer_v3"
+  name: "gnosis_balancer_v3"
   version: v0.4.0
 
 protobuf:
@@ -18,7 +18,7 @@ binaries:
 modules:
   - name: map_components
     kind: map
-    initialBlock: 21332121
+    initialBlock: 37360338
     inputs:
       - params: string
       - source: sf.ethereum.type.v2.Block
@@ -27,7 +27,7 @@ modules:
 
   - name: store_components
     kind: store
-    initialBlock: 21332121
+    initialBlock: 37360338
     updatePolicy: set_if_not_exists
     valueType: proto:tycho.evm.v1.ProtocolComponents
     inputs:
@@ -35,7 +35,7 @@ modules:
 
   - name: store_token_set
     kind: store
-    initialBlock: 21332121
+    initialBlock: 37360338
     updatePolicy: set_if_not_exists
     valueType: int64
     inputs:
@@ -43,7 +43,7 @@ modules:
 
   - name: map_relative_balances
     kind: map
-    initialBlock: 21332121
+    initialBlock: 37360338
     inputs:
       - params: string
       - source: sf.ethereum.type.v2.Block
@@ -53,7 +53,7 @@ modules:
 
   - name: store_balances
     kind: store
-    initialBlock: 21332121
+    initialBlock: 37360338
     updatePolicy: add
     valueType: bigint
     inputs:
@@ -61,7 +61,7 @@ modules:
 
   - name: map_protocol_changes
     kind: map
-    initialBlock: 21332121
+    initialBlock: 37360338
     inputs:
       - params: string
       - source: sf.ethereum.type.v2.Block
@@ -70,13 +70,13 @@ modules:
       - store: store_components
       - store: store_token_set
       - store: store_balances
-        mode: deltas # This is the key property that simplifies `BalanceChange` handling
+        mode: deltas
     output:
       type: proto:tycho.evm.v1.BlockChanges
 
 network: mainnet
 
 params:
-  map_components: vault=ba1333333333a1ba1108e8412f11850a5c319ba9&vault_extension=0e8b07657d719b86e06bf0806d6729e3d528c9a9&batch_router=136f1efcc3f8f88516b9e94110d56fdbfb1778d1&permit2=000000000022d473030f116ddee9f6b43ac78ba3&weighted_factory=201efd508c8dfe9de1a13c2452863a78cb2a86cc&stable_factory=b9d01ca61b9c181da1051bfdd28e1097e920ab14
-  map_relative_balances: vault=ba1333333333a1ba1108e8412f11850a5c319ba9&vault_extension=0e8b07657d719b86e06bf0806d6729e3d528c9a9&batch_router=136f1efcc3f8f88516b9e94110d56fdbfb1778d1&permit2=000000000022d473030f116ddee9f6b43ac78ba3&weighted_factory=201efd508c8dfe9de1a13c2452863a78cb2a86cc&stable_factory=b9d01ca61b9c181da1051bfdd28e1097e920ab14
-  map_protocol_changes: vault=ba1333333333a1ba1108e8412f11850a5c319ba9&vault_extension=0e8b07657d719b86e06bf0806d6729e3d528c9a9&batch_router=136f1efcc3f8f88516b9e94110d56fdbfb1778d1&permit2=000000000022d473030f116ddee9f6b43ac78ba3&weighted_factory=201efd508c8dfe9de1a13c2452863a78cb2a86cc&stable_factory=b9d01ca61b9c181da1051bfdd28e1097e920ab14
+  map_components: vault=ba1333333333a1ba1108e8412f11850a5c319ba9&vault_extension=0e8b07657d719b86e06bf0806d6729e3d528c9a9&batch_router=e2fa4e1d17725e72dcdafe943ecf45df4b9e285b&permit2=000000000022d473030f116ddee9f6b43ac78ba3&weighted_factory=78ad1e1c10033b18ceaa20088e4e490be42a5417&stable_factory=9338f9484120fdfe8f8abea8e5d6d9d8d055962d
+  map_relative_balances: vault=ba1333333333a1ba1108e8412f11850a5c319ba9&vault_extension=0e8b07657d719b86e06bf0806d6729e3d528c9a9&batch_router=e2fa4e1d17725e72dcdafe943ecf45df4b9e285b&permit2=000000000022d473030f116ddee9f6b43ac78ba3&weighted_factory=78ad1e1c10033b18ceaa20088e4e490be42a5417&stable_factory=9338f9484120fdfe8f8abea8e5d6d9d8d055962d
+  map_protocol_changes: vault=ba1333333333a1ba1108e8412f11850a5c319ba9&vault_extension=0e8b07657d719b86e06bf0806d6729e3d528c9a9&batch_router=e2fa4e1d17725e72dcdafe943ecf45df4b9e285b&permit2=000000000022d473030f116ddee9f6b43ac78ba3&weighted_factory=78ad1e1c10033b18ceaa20088e4e490be42a5417&stable_factory=9338f9484120fdfe8f8abea8e5d6d9d8d055962d

--- a/substreams/ethereum-balancer-v3/integration_test_balancer_v3.tycho.yaml
+++ b/substreams/ethereum-balancer-v3/integration_test_balancer_v3.tycho.yaml
@@ -1,0 +1,29 @@
+substreams_yaml_path: ./base-balancer-v3.yaml
+protocol_system: "vm:balancer_v3"
+module_name: "map_protocol_changes"
+protocol_type_names:
+  - "balancer_v3_pool"
+adapter_contract: "BalancerV3SwapAdapter"
+adapter_build_signature: "constructor(address,address,address,address)"
+adapter_build_args: "0xbA1333333333a1BA1108E8412f11850A5C319bA9,0x85a80afee867aDf27B50BdB7b76DA70f1E853062,0x000000000022D473030F116dDEE9F6B43aC78BA3,0x4200000000000000000000000000000000000006"
+skip_balance_check: true
+
+initialized_accounts:
+  - "0xbA1333333333a1BA1108E8412f11850A5C319bA9"
+
+tests:
+  - name: test_base_weighted_pool_creation
+    start_block: 30270920
+    stop_block: 30270935
+    expected_components:
+      - id: "0xCC8DAD6E87deb75fA82E7c4dd08B58d368214812"
+        tokens:
+          - "0x74299A718b2c44483a27325d7725F0B2646DE3B1"
+          - "0xC768c589647798a6EE01A91FdE98EF2ed046DBD6"
+        static_attributes:
+          manual_updates: "0x01"
+          normalized_weights: "0x5b22307830623161326263326563353030303030222c22307830326336386166306262313430303030225d"
+          fee: "0x0aa87bee538000"
+          pool_type: "0x5765696768746564506f6f6c466163746f7279"
+        skip_simulation: true
+        creation_tx: "0xe62361b12a708c5752c1f4c9aeae7bae4f884eb2a480d2ee9ccfc69adc659112"

--- a/substreams/ethereum-balancer-v3/src/modules.rs
+++ b/substreams/ethereum-balancer-v3/src/modules.rs
@@ -5,12 +5,13 @@ use crate::{
     },
     pool_factories,
 };
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use itertools::Itertools;
 use keccak_hash::keccak;
+use serde::Deserialize;
 use std::collections::HashMap;
 use substreams::{
-    hex, log,
+    log,
     pb::substreams::StoreDeltas,
     store::{
         StoreAddBigInt, StoreGet, StoreGetInt64, StoreGetProto, StoreNew, StoreSetIfNotExists,
@@ -27,19 +28,69 @@ use tycho_substreams::{
     entrypoint::create_entrypoint, models::entry_point_params::TraceData, prelude::*,
 };
 
-pub const VAULT_ADDRESS: &[u8] = &hex!("bA1333333333a1BA1108E8412f11850A5C319bA9");
-pub const VAULT_EXTENSION_ADDRESS: &[u8; 20] = &hex!("0E8B07657D719B86e06bF0806D6729e3D528C9A9");
-pub const BATCH_ROUTER_ADDRESS: &[u8; 20] = &hex!("136f1efcc3f8f88516b9e94110d56fdbfb1778d1");
-pub const PERMIT_2_ADDRESS: &[u8; 20] = &hex!("000000000022D473030F116dDEE9F6B43aC78BA3");
+#[derive(Debug, Deserialize)]
+pub struct BalancerV3Config {
+    pub vault: String,
+    pub vault_extension: String,
+    pub batch_router: String,
+    pub permit2: String,
+    pub weighted_factory: String,
+    pub stable_factory: String,
+}
+
+impl BalancerV3Config {
+    pub fn parse_from_query(input: &str) -> Result<Self> {
+        serde_qs::from_str(input).map_err(|e| anyhow!("Failed to parse query params: {e}"))
+    }
+
+    fn decode_address(value: &str, name: &str) -> Result<[u8; 20]> {
+        let address = hex::decode(value).map_err(|e| anyhow!("Invalid {name} hex: {e}"))?;
+        if address.len() != 20 {
+            return Err(anyhow!("{name} must be 20 bytes long"));
+        }
+
+        Ok(address
+            .try_into()
+            .expect("validated that address has 20 bytes"))
+    }
+
+    pub fn vault_address(&self) -> Result<[u8; 20]> {
+        Self::decode_address(&self.vault, "vault")
+    }
+
+    pub fn vault_extension_address(&self) -> Result<[u8; 20]> {
+        Self::decode_address(&self.vault_extension, "vault_extension")
+    }
+
+    pub fn batch_router_address(&self) -> Result<[u8; 20]> {
+        Self::decode_address(&self.batch_router, "batch_router")
+    }
+
+    pub fn permit2_address(&self) -> Result<[u8; 20]> {
+        Self::decode_address(&self.permit2, "permit2")
+    }
+
+    pub fn weighted_factory_address(&self) -> Result<[u8; 20]> {
+        Self::decode_address(&self.weighted_factory, "weighted_factory")
+    }
+
+    pub fn stable_factory_address(&self) -> Result<[u8; 20]> {
+        Self::decode_address(&self.stable_factory, "stable_factory")
+    }
+}
 
 #[substreams::handlers::map]
-pub fn map_components(block: eth::v2::Block) -> Result<BlockTransactionProtocolComponents> {
+pub fn map_components(
+    params: String,
+    block: eth::v2::Block,
+) -> Result<BlockTransactionProtocolComponents> {
+    let config = BalancerV3Config::parse_from_query(&params)?;
     let mut tx_components = Vec::new();
     for tx in block.transactions() {
         let mut components = Vec::new();
         for (log, call) in tx.logs_with_calls() {
             if let Some(component) =
-                pool_factories::address_map(log.address.as_slice(), log, call.call)
+                pool_factories::address_map(&config, log.address.as_slice(), log, call.call)
             {
                 components.push(component);
             }
@@ -87,12 +138,15 @@ pub fn store_token_set(map: BlockTransactionProtocolComponents, store: StoreSetI
 
 #[substreams::handlers::map]
 pub fn map_relative_balances(
+    params: String,
     block: eth::v2::Block,
     store: StoreGetProto<ProtocolComponent>,
 ) -> Result<BlockBalanceDeltas, anyhow::Error> {
+    let config = BalancerV3Config::parse_from_query(&params)?;
+    let vault_address = config.vault_address()?;
     let balance_deltas = block
         .logs()
-        .filter(|log| log.address() == VAULT_ADDRESS)
+        .filter(|log| log.address() == vault_address)
         .flat_map(|vault_log| {
             let mut deltas = Vec::new();
 
@@ -210,6 +264,7 @@ pub fn store_balances(deltas: BlockBalanceDeltas, store: StoreAddBigInt) {
 /// `BlockChanges`  is ordered by transactions properly.
 #[substreams::handlers::map]
 pub fn map_protocol_changes(
+    params: String,
     block: eth::v2::Block,
     grouped_components: BlockTransactionProtocolComponents,
     deltas: BlockBalanceDeltas,
@@ -217,6 +272,11 @@ pub fn map_protocol_changes(
     tokens_store: StoreGetInt64,
     balance_store: StoreDeltas, // Note, this map module is using the `deltas` mode for the store.
 ) -> Result<BlockChanges> {
+    let config = BalancerV3Config::parse_from_query(&params)?;
+    let vault_address = config.vault_address()?;
+    let vault_extension_address = config.vault_extension_address()?;
+    let batch_router_address = config.batch_router_address()?;
+    let permit2_address = config.permit2_address()?;
     // We merge contract changes by transaction (identified by transaction index) making it easy to
     //  sort them at the very end.
     let mut transaction_changes: HashMap<_, TransactionChangesBuilder> = HashMap::new();
@@ -224,7 +284,7 @@ pub fn map_protocol_changes(
     // Handle pool pause state changes
     block
         .logs()
-        .filter(|log| log.address() == VAULT_ADDRESS)
+        .filter(|log| log.address() == vault_address)
         .for_each(|log| {
             if let Some(PoolPausedStateChanged { pool, paused }) =
                 PoolPausedStateChanged::match_and_decode(log)
@@ -262,22 +322,22 @@ pub fn map_protocol_changes(
         Attribute {
             // TODO: remove this and track account_balances instead
             name: "balance_owner".to_string(),
-            value: VAULT_ADDRESS.to_vec(),
+            value: vault_address.to_vec(),
             change: ChangeType::Creation.into(),
         },
         Attribute {
             name: "stateless_contract_addr_0".into(),
-            value: address_to_bytes_with_0x(VAULT_EXTENSION_ADDRESS),
+            value: address_to_bytes_with_0x(&vault_extension_address),
             change: ChangeType::Creation.into(),
         },
         Attribute {
             name: "stateless_contract_addr_1".into(),
-            value: address_to_bytes_with_0x(BATCH_ROUTER_ADDRESS),
+            value: address_to_bytes_with_0x(&batch_router_address),
             change: ChangeType::Creation.into(),
         },
         Attribute {
             name: "stateless_contract_addr_2".into(),
-            value: address_to_bytes_with_0x(PERMIT_2_ADDRESS),
+            value: address_to_bytes_with_0x(&permit2_address),
             change: ChangeType::Creation.into(),
         },
         Attribute {
@@ -360,7 +420,7 @@ pub fn map_protocol_changes(
             components_store
                 .get_last(format!("pool:0x{0}", hex::encode(addr)))
                 .is_some() ||
-                addr.eq(VAULT_ADDRESS)
+                addr.eq(&vault_address)
         },
         &mut transaction_changes,
     );
@@ -371,7 +431,7 @@ pub fn map_protocol_changes(
         .iter()
         .for_each(|tx| {
             let vault_balance_change_per_tx =
-                get_vault_reserves(tx, &components_store, &tokens_store);
+                get_vault_reserves(tx, &vault_address, &components_store, &tokens_store);
 
             if !vault_balance_change_per_tx.is_empty() {
                 let tycho_tx = Transaction::from(tx);
@@ -380,7 +440,7 @@ pub fn map_protocol_changes(
                     .or_insert_with(|| TransactionChangesBuilder::new(&tycho_tx));
 
                 let mut vault_contract_tlv_changes =
-                    InterimContractChange::new(VAULT_ADDRESS, false);
+                    InterimContractChange::new(&vault_address, false);
                 for (token_addr, reserve_value) in vault_balance_change_per_tx {
                     vault_contract_tlv_changes.upsert_token_balance(
                         token_addr.as_slice(),
@@ -403,7 +463,7 @@ pub fn map_protocol_changes(
             addresses
                 .into_iter()
                 .for_each(|address| {
-                    if address != VAULT_ADDRESS {
+                    if address != vault_address {
                         // We reconstruct the component_id from the address here
                         let id = components_store
                             .get_last(format!("pool:0x{}", hex::encode(address)))
@@ -444,6 +504,7 @@ fn address_to_string_with_0x(address: &[u8]) -> String {
 // they should always be equal to the `token.balanceOf(this)` except during unlock
 fn get_vault_reserves(
     transaction: &eth::v2::TransactionTrace,
+    vault_address: &[u8; 20],
     store: &StoreGetProto<ProtocolComponent>,
     token_store: &StoreGetInt64,
 ) -> HashMap<Vec<u8>, ReserveValue> {
@@ -453,7 +514,7 @@ fn get_vault_reserves(
         .calls
         .iter()
         .filter(|call| !call.state_reverted)
-        .filter(|call| call.address == VAULT_ADDRESS)
+        .filter(|call| call.address == *vault_address)
         .for_each(|call| {
             if let Some(Settle { token, .. }) = Settle::match_and_decode(call) {
                 for change in &call.storage_changes {

--- a/substreams/ethereum-balancer-v3/src/pool_factories.rs
+++ b/substreams/ethereum-balancer-v3/src/pool_factories.rs
@@ -1,4 +1,4 @@
-use crate::{abi, modules::VAULT_ADDRESS};
+use crate::{abi, modules::BalancerV3Config};
 use abi::{
     stable_pool_factory_contract::{
         events::PoolCreated as StablePoolCreated, functions::Create as StablePoolCreate,
@@ -7,7 +7,7 @@ use abi::{
         events::PoolCreated as WeightedPoolCreated, functions::Create as WeightedPoolCreate,
     },
 };
-use substreams::{hex, scalar::BigInt};
+use substreams::scalar::BigInt;
 use substreams_ethereum::{
     pb::eth::v2::{Call, Log},
     Event, Function,
@@ -29,12 +29,22 @@ pub fn collect_rate_providers(tokens: &TokenConfig) -> Vec<Vec<u8>> {
 }
 
 pub fn address_map(
+    config: &BalancerV3Config,
     pool_factory_address: &[u8],
     log: &Log,
     call: &Call,
 ) -> Option<ProtocolComponent> {
-    match *pool_factory_address {
-        hex!("201efd508c8DfE9DE1a13c2452863A78CB2a86Cc") => {
+    let weighted_factory = config
+        .weighted_factory_address()
+        .expect("weighted_factory should always be a valid 20-byte hex address");
+    let stable_factory = config
+        .stable_factory_address()
+        .expect("stable_factory should always be a valid 20-byte hex address");
+    let vault_address =
+        config.vault_address().expect("vault should always be a valid 20-byte hex address");
+
+    match pool_factory_address {
+        addr if addr == weighted_factory => {
             let WeightedPoolCreate {
                 tokens: token_config,
                 normalized_weights,
@@ -71,13 +81,13 @@ pub fn address_map(
 
             Some(
                 ProtocolComponent::new(&format!("0x{}", hex::encode(&pool)))
-                    .with_contracts(&[pool, VAULT_ADDRESS.to_vec()])
+                    .with_contracts(&[pool, vault_address.to_vec()])
                     .with_tokens(tokens.as_slice())
                     .with_attributes(&attributes)
                     .as_swap_type("balancer_v3_pool", ImplementationType::Vm),
             )
         }
-        hex!("B9d01CA61b9C181dA1051bFDd28e1097e920AB14") => {
+        addr if addr == stable_factory => {
             let StablePoolCreate { tokens: token_config, swap_fee_percentage, .. } =
                 StablePoolCreate::match_and_decode(call)?;
             let StablePoolCreated { pool } = StablePoolCreated::match_and_decode(log)?;
@@ -108,7 +118,7 @@ pub fn address_map(
 
             Some(
                 ProtocolComponent::new(&format!("0x{}", hex::encode(&pool)))
-                    .with_contracts(&[pool.to_owned(), VAULT_ADDRESS.to_vec()])
+                    .with_contracts(&[pool.to_owned(), vault_address.to_vec()])
                     .with_tokens(tokens.as_slice())
                     .with_attributes(&attributes)
                     .as_swap_type("balancer_v3_pool", ImplementationType::Vm),


### PR DESCRIPTION
Add Balancer V3 multi-network manifests (Base, Arbitrum, Gnosis) and Base test config. This PR extends ethereum-balancer-v3 to support additional networks via manifest-level configuration, reusing the same WASM/module graph and chain-specific params.
Base includes a creation-path integration test config.
Arbitrum and Gnosis are added as manifest support only for now (no integration-test wiring), consistent with current repo precedent for some non-Ethereum manifests.